### PR TITLE
fix: filter resource completion candidates by HTTP method

### DIFF
--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -63,8 +63,11 @@ def _find_op(
     return next((o for o in apidef[template] if o["method"] == method), None)
 
 
-def _complete_resources(apidef: dict[str, Any], incomplete: str) -> list[str]:
-    return [p for p in sorted(apidef.keys()) if p.startswith(incomplete)]
+def _complete_resources(apidef: dict[str, Any], method: str, incomplete: str) -> list[str]:
+    return [
+        p for p in sorted(apidef.keys())
+        if p.startswith(incomplete) and any(o["method"] == method for o in apidef[p])
+    ]
 
 
 def _complete_param_names(
@@ -138,7 +141,7 @@ def completions_for_context(
     if current == 2:
         if apidef is None:
             return []
-        return _complete_resources(apidef, incomplete)
+        return _complete_resources(apidef, method, incomplete)
 
     resource = words[2] if len(words) > 2 else ""
     prev = words[current - 1] if current >= 1 else ""

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -101,9 +101,18 @@ def test_top_level_commands_covers_expected() -> None:
 
 def test_complete_resource_all() -> None:
     result = ctx(["papycli", "get", ""], 2)
-    assert "/pet" in result
+    # /pet has only POST and PUT — must not appear for GET
+    assert "/pet" not in result
     assert "/pet/findByStatus" in result
     assert "/store/inventory" in result
+
+
+def test_complete_resource_method_filter_post() -> None:
+    # /pet supports POST; /pet/findByStatus and /store/inventory do not
+    result = ctx(["papycli", "post", ""], 2)
+    assert "/pet" in result
+    assert "/pet/findByStatus" not in result
+    assert "/store/inventory" not in result
 
 
 def test_complete_resource_prefix() -> None:


### PR DESCRIPTION
Closes #7

## Summary

- `_complete_resources` now accepts `method` and filters paths to only those with a matching operation
- Previously, `papycli get /store/order<TAB>` showed POST-only paths as candidates
- Updated `test_complete_resource_all` to assert POST/PUT-only paths are excluded from GET completions
- Added `test_complete_resource_method_filter_post` to verify the same for POST

## Test plan

- [ ] `uv run pytest` — 179 tests pass
- [ ] `papycli get <TAB>` — only paths with GET operations appear
- [ ] `papycli post <TAB>` — only paths with POST operations appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)