### PR TITLE
feat: rename config show to config list

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -160,7 +160,7 @@ papycli config use myapi
 papycli config remove petstore-oas3
 
 # 登録済み API と現在のデフォルトを確認する
-papycli config show
+papycli config list
 ```
 
 ---
@@ -172,7 +172,7 @@ papycli config show
 papycli config add <spec-file>             OpenAPI spec ファイルから API を登録する
 papycli config remove <api-name>           登録済み API を削除する
 papycli config use <api-name>              アクティブな API を切り替える
-papycli config show                        現在の設定を表示する
+papycli config list                        登録済み API と現在の設定を一覧表示する
 papycli config completion-script <bash|zsh>  シェル補完スクリプトを出力する
 
 # API 呼び出しコマンド

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ papycli config use myapi
 papycli config remove petstore-oas3
 
 # Show registered APIs and the current default
-papycli config show
+papycli config list
 ```
 
 ---
@@ -174,7 +174,7 @@ papycli config show
 papycli config add <spec-file>             Register an API from an OpenAPI spec file
 papycli config remove <api-name>           Remove a registered API
 papycli config use <api-name>              Switch the active API
-papycli config show                        Show current configuration
+papycli config list                        List registered APIs and current configuration
 papycli config completion-script <bash|zsh>  Print a shell completion script
 
 # API call commands

--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 METHODS = ["get", "post", "put", "patch", "delete"]
-CONFIG_SUBCOMMANDS = ["add", "completion-script", "remove", "show", "use"]
+CONFIG_SUBCOMMANDS = ["add", "completion-script", "list", "remove", "use"]
 TOP_LEVEL_COMMANDS = METHODS + ["config", "summary"]
 
 # ---------------------------------------------------------------------------

--- a/src/papycli/main.py
+++ b/src/papycli/main.py
@@ -160,10 +160,10 @@ def cmd_config_remove(api_name: str) -> None:
 
 
 @cmd_config.command(
-    "show",
-    help=h("Show current configuration.", "現在の設定を表示する。"),
+    "list",
+    help=h("List registered APIs and current configuration.", "登録済み API と現在の設定を一覧表示する。"),
 )
-def cmd_config_show() -> None:
+def cmd_config_list() -> None:
     conf_dir = get_conf_dir()
     conf_path = get_conf_path(conf_dir)
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -136,18 +136,18 @@ def test_complete_config_subcommands_empty() -> None:
     assert "add" in result
     assert "remove" in result
     assert "use" in result
-    assert "show" in result
+    assert "list" in result
     assert "completion-script" in result
 
 
 def test_complete_config_subcommands_prefix() -> None:
-    result = ctx(["papycli", "config", "s"], 2)
-    assert "show" in result
+    result = ctx(["papycli", "config", "l"], 2)
+    assert "list" in result
     assert "add" not in result
 
 
 def test_complete_config_subcommands_covers_all() -> None:
-    assert set(CONFIG_SUBCOMMANDS) == {"add", "remove", "use", "show", "completion-script"}
+    assert set(CONFIG_SUBCOMMANDS) == {"add", "remove", "use", "list", "completion-script"}
 
 
 def test_complete_config_no_further_completion() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,7 +90,7 @@ def test_config_no_subcommand_shows_help() -> None:
     assert result.exit_code == 0
     assert "add" in result.output
     assert "use" in result.output
-    assert "show" in result.output
+    assert "list" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -277,25 +277,25 @@ def test_cmd_remove_reserved_key_default(
 
 
 # ---------------------------------------------------------------------------
-# papycli config show
+# papycli config list
 # ---------------------------------------------------------------------------
 
 
-def test_cmd_conf_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cmd_list_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PAPYCLI_CONF_DIR", str(tmp_path))
     runner = CliRunner()
-    result = runner.invoke(cli, ["config", "show"])
+    result = runner.invoke(cli, ["config", "list"])
     assert result.exit_code == 0
     assert str(tmp_path) in result.output
 
 
-def test_cmd_conf_after_add(
+def test_cmd_list_after_add(
     tmp_path: Path, minimal_spec_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("PAPYCLI_CONF_DIR", str(tmp_path))
     runner = CliRunner()
     runner.invoke(cli, ["config", "add", str(minimal_spec_file)])
-    result = runner.invoke(cli, ["config", "show"])
+    result = runner.invoke(cli, ["config", "list"])
     assert result.exit_code == 0
     assert "myapi" in result.output
     assert "http://localhost:9000/api" in result.output


### PR DESCRIPTION
## Summary

- Rename `papycli config show` → `papycli config list` (command name and help text only)
- Update `CONFIG_SUBCOMMANDS` in `completion.py`
- Update all tests, README.md, and README.ja.md

## Test plan

- [ ] All 191 tests pass (`pytest tests/`)
- [ ] `papycli config list` displays the configuration correctly
- [ ] `papycli config` (no subcommand) shows `list` in the help output
- [ ] Tab completion suggests `list` after `papycli config <TAB>`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)