### PR TITLE
docs: update CLAUDE.md, design_doc.md, README for issues #9-#12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,27 +37,38 @@ papycli/
 │   └── papycli/
 │       ├── __init__.py
 │       ├── main.py          # エントリポイント・引数パース
-│       ├── init_cmd.py      # --init コマンド（spec の変換・保存）
+│       ├── init_cmd.py      # config add コマンド（spec の変換・保存）
 │       ├── api_call.py      # HTTP リクエスト実行
 │       ├── completion.py    # シェル補完スクリプト生成
 │       ├── config.py        # 設定ファイルの読み書き
+│       ├── i18n.py          # 日英ヘルプテキストの切り替えユーティリティ
 │       ├── spec_loader.py   # OpenAPI spec の読み込み・$ref 解決
-│       └── summary.py       # --summary / --summary-csv
+│       └── summary.py       # summary コマンド・CSV 出力
 ├── tests/
+│   ├── test_api_call.py
+│   ├── test_completion.py
+│   ├── test_config.py
+│   ├── test_i18n.py
+│   ├── test_init_cmd.py
+│   ├── test_main.py
+│   ├── test_spec_loader.py
+│   └── test_summary.py
 ├── examples/
 │   ├── docker-compose.yml
 │   └── petstore-oas3.json
 ├── pyproject.toml
 ├── README.md
+├── README.ja.md
+├── design_doc.md
 └── CLAUDE.md
 ```
 
 ### 主要モジュール
 
 **`main.py`** — CLI エントリポイント
-引数をパースし、各コマンド（`init`、`use`、`conf`、`summary`、`completion-script`、メソッド呼び出し）に処理を委譲する。シェル補完用の `_complete` 内部コマンドもここで定義する。
+引数をパースし、各コマンド（`config add`/`use`/`remove`/`list`/`completion-script`、`summary`、メソッド呼び出し）に処理を委譲する。シェル補完用の `_complete` 内部コマンドもここで定義する。
 
-**`init_cmd.py`** — API 初期化
+**`init_cmd.py`** — API 初期化（`config add` コマンドの実処理）
 OpenAPI spec ファイルを受け取り、`$ref` を解決した上で papycli 内部の API 定義フォーマットに変換し、`$PAPYCLI_CONF_DIR/apis/<name>.json` に保存する。設定ファイル (`papycli.conf`) も更新する。
 
 **`spec_loader.py`** — spec 読み込み・変換
@@ -139,11 +150,12 @@ bash / zsh 向けの補完スクリプトを生成する。補完の候補はメ
 
 ```
 papycli <method> <resource> [options]
-papycli init <spec-file>
-papycli use <api-name>
-papycli conf
+papycli config add <spec-file>
+papycli config use <api-name>
+papycli config remove <api-name>
+papycli config list
+papycli config completion-script <bash|zsh>
 papycli summary [resource] [--csv]
-papycli completion-script <bash|zsh>
 papycli --version
 papycli --help / -h
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -103,12 +103,18 @@ $ papycli get <TAB>
   /pet/findByStatus  /pet/{petId}  /store/inventory  ...
 
 $ papycli get /pet/findByStatus <TAB>
-  -q  --summary  --help
+  -q  -p  -H  -d  --summary  --verbose
 
 $ papycli get /pet/findByStatus -q <TAB>
   status
 
 $ papycli get /pet/findByStatus -q status <TAB>
+  available  pending  sold
+
+$ papycli post /pet -p <TAB>
+  name  status  photoUrls
+
+$ papycli post /pet -p status <TAB>
   available  pending  sold
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,18 @@ $ papycli get <TAB>
   /pet/findByStatus  /pet/{petId}  /store/inventory  ...
 
 $ papycli get /pet/findByStatus <TAB>
-  -q  --summary  --help
+  -q  -p  -H  -d  --summary  --verbose
 
 $ papycli get /pet/findByStatus -q <TAB>
   status
 
 $ papycli get /pet/findByStatus -q status <TAB>
+  available  pending  sold
+
+$ papycli post /pet -p <TAB>
+  name  status  photoUrls
+
+$ papycli post /pet -p status <TAB>
   available  pending  sold
 ```
 

--- a/design_doc.md
+++ b/design_doc.md
@@ -4,7 +4,7 @@
 
 - Python 3.12 / uv でパッケージ管理
 - `examples/petstore-oas3.json` と `examples/docker-compose.yml` 準備済み
-- ソースコードはまだない状態
+- Milestone 1〜5 の実装が完了し、`papycli` コマンドとして動作する状態
 
 ---
 
@@ -35,16 +35,19 @@ papycli/
 │       ├── main.py          # CLI エントリポイント（click コマンド定義）
 │       ├── config.py        # 設定ファイル (papycli.conf) の読み書き
 │       ├── spec_loader.py   # OpenAPI spec 読み込み・$ref 解決・内部形式変換
-│       ├── init_cmd.py      # --init コマンドの処理
+│       ├── init_cmd.py      # config add コマンドの処理
 │       ├── api_call.py      # HTTP リクエスト実行・パステンプレートマッチング
-│       ├── summary.py       # --summary / --summary-csv の出力
-│       └── completion.py    # bash / zsh 補完スクリプト生成
+│       ├── summary.py       # summary コマンドの出力
+│       ├── completion.py    # bash / zsh 補完スクリプト生成
+│       └── i18n.py          # 日英ヘルプテキストの切り替えユーティリティ
 ├── tests/
-│   ├── conftest.py          # pytest fixtures
-│   ├── test_spec_loader.py
-│   ├── test_config.py
-│   ├── test_init_cmd.py
 │   ├── test_api_call.py
+│   ├── test_completion.py
+│   ├── test_config.py
+│   ├── test_i18n.py
+│   ├── test_init_cmd.py
+│   ├── test_main.py
+│   ├── test_spec_loader.py
 │   └── test_summary.py
 ├── examples/
 │   ├── docker-compose.yml
@@ -52,6 +55,7 @@ papycli/
 ├── design_doc.md
 ├── CLAUDE.md
 ├── README.md
+├── README.ja.md
 ├── pyproject.toml
 └── uv.lock
 ```
@@ -125,7 +129,7 @@ papycli/
 
 ---
 
-### Milestone 2 — spec ローダーと `--init` / `--conf` / `--use`
+### Milestone 2 — spec ローダーと `config add` / `config list` / `config use`
 
 **目的**: OpenAPI spec を読み込んで内部形式に変換し、設定ファイルを管理できるようにする。
 
@@ -139,15 +143,16 @@ papycli/
 - `config.py`
   - `PAPYCLI_CONF_DIR` 環境変数の解決（デフォルト `~/.papycli`）
   - `papycli.conf` の読み書き
+  - API エントリの登録・削除・デフォルト変更
 - `init_cmd.py`
   - spec ロード → 変換 → `apis/<name>.json` 保存 → conf 更新
-- `main.py` に `--init`、`--use`、`--conf` コマンド追加
+- `main.py` に `config add`、`config use`、`config remove`、`config list` コマンド追加
 - テスト: `test_spec_loader.py`、`test_config.py`、`test_init_cmd.py`
   - `$ref` 解決のパターン（内部参照、外部参照、循環参照ガード）
   - 変換結果の検証（petstore-oas3.json を使用）
   - config の CRUD
 
-**完了条件**: `papycli --init examples/petstore-oas3.json` が成功し、`~/.papycli/apis/petstore-oas3.json` が正しい内容で生成される。`papycli --conf` で設定が表示される。テストがパスする。
+**完了条件**: `papycli config add examples/petstore-oas3.json` が成功し、`~/.papycli/apis/petstore-oas3.json` が正しい内容で生成される。`papycli config list` で設定が表示される。テストがパスする。
 
 ---
 
@@ -214,7 +219,7 @@ papycli/
 - `main.py` に `--completion-script <bash|zsh>` コマンド追加
 - 手動テスト手順をドキュメント化
 
-**完了条件**: `eval "$(papycli --completion-script zsh)"` 後にタブ補完が動作する。メソッド・リソース・パラメータ名・enum 値が補完候補として表示される。
+**完了条件**: `eval "$(papycli config completion-script zsh)"` 後にタブ補完が動作する。メソッド・リソース・クエリパラメータ名・ボディパラメータ名・enum 値が補完候補として表示される。
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #17.

issue #9〜#12 のコード変更に合わせてドキュメントを更新します。

## Changes

### CLAUDE.md
- ディレクトリ構成に `i18n.py` を追加、`tests/` 配下の全ファイルを列挙、`README.ja.md`・`design_doc.md` を追記
- `init_cmd.py` のコメントを `--init コマンド` → `config add コマンド` に修正
- `main.py` の説明を旧コマンド名（`init`/`use`/`conf`/`completion-script`）から現行（`config add`/`use`/`remove`/`list`/`completion-script`）に更新
- CLI 仕様のコマンド構文を全面更新（`papycli init`/`use`/`conf`/`completion-script` → `papycli config add`/`use`/`remove`/`list`/`completion-script`）

### design_doc.md
- 「現状」セクション: 「ソースコードはまだない状態」→ 「Milestone 1〜5 の実装が完了」に修正
- プロジェクト構成: `i18n.py`・`README.ja.md` を追加、`tests/` 配下を現実に合わせて更新
- Milestone 2: コマンド名（`--init`/`--conf`/`--use`）と完了条件を現行 CLI に合わせて更新
- Milestone 5: 完了条件の `papycli --completion-script` → `papycli config completion-script` に修正

### README.md / README.ja.md
- タブ補完セクション: オプション一覧を `-q -p -H -d --summary --verbose` に修正
- タブ補完セクション: issue #12 で実装した `-p` ボディパラメータ名・enum 値補完の例を追加

## Test plan

- [x] ドキュメントの記述が現行 CLI（`papycli config add`/`remove`/`list`/`use`/`completion-script`）と一致することを確認
- [x] タブ補完例が `-q`/`-p` 両方を示していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)