### PR TITLE
feat: bash completion fallback to file paths after config add

### DIFF
--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -22,6 +22,13 @@ BASH_SCRIPT = """\
 _papycli_completion() {
     local IFS=$'\\n'
     COMPREPLY=($(papycli _complete "${COMP_CWORD}" "${COMP_WORDS[@]}" 2>/dev/null))
+    if [[ ${#COMPREPLY[@]} -eq 0 \\
+          && "${COMP_WORDS[1]}" == "config" \\
+          && "${COMP_WORDS[2]}" == "add" \\
+          && "${COMP_CWORD}" -eq 3 ]]; then
+        COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
+        compopt -o filenames 2>/dev/null
+    fi
 }
 complete -o nospace -F _papycli_completion papycli
 """

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -335,6 +335,20 @@ def test_generate_bash_has_comp_words() -> None:
     assert "COMP_CWORD" in script
 
 
+def test_generate_bash_has_config_add_file_fallback() -> None:
+    script = generate_script("bash")
+    assert "compgen -f" in script
+    assert "compopt -o filenames" in script
+
+
+def test_generate_bash_config_add_fallback_condition() -> None:
+    script = generate_script("bash")
+    # config add コンテキストを検出する条件が含まれていること
+    assert '"config"' in script
+    assert '"add"' in script
+    assert "COMP_CWORD" in script
+
+
 def test_generate_zsh_has_current() -> None:
     script = generate_script("zsh")
     assert "CURRENT" in script


### PR DESCRIPTION
## Summary

Closes #19.

`papycli config add <TAB>` で補完候補が表示されなかった問題を修正します。

## Changes

### `src/papycli/completion.py`

`BASH_SCRIPT` 内の `_papycli_completion` 関数を拡張。`papycli _complete` が候補を返さない場合（＝ `config add` の引数位置）に `compgen -f` でファイルパス補完にフォールバックする。

```bash
if [[ ${#COMPREPLY[@]} -eq 0       && "${COMP_WORDS[1]}" == "config"       && "${COMP_WORDS[2]}" == "add"       && "${COMP_CWORD}" -eq 3 ]]; then
    COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
    compopt -o filenames 2>/dev/null
fi
```

- `compgen -f` — カレントディレクトリ配下のファイル・ディレクトリを列挙
- `compopt -o filenames` — ディレクトリには `/` を付与（ネスト探索を可能にする）
- Python 側の `completions_for_context` は変更なし（`config add` 引数位置で空リストを返し続けることでフォールバックが発動する）

### `tests/test_completion.py`

- `test_generate_bash_has_config_add_file_fallback` — `compgen -f` と `compopt -o filenames` がスクリプトに含まれることを確認
- `test_generate_bash_config_add_fallback_condition` — `config`/`add` の条件判定がスクリプトに含まれることを確認

## Test plan

- [x] `pytest tests/test_completion.py` — 37 passed
- [x] `pytest` (full suite) — 195 passed
- [ ] 手動確認: `eval "$(papycli config completion-script bash)"` 後に `papycli config add <TAB>` でファイル一覧が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)