### PR TITLE
feat: GitHub Actions release workflow (GitHub Release + PyPI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag version matches pyproject.toml
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python3 -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Version mismatch: tag=$TAG_VERSION, pyproject.toml=$PKG_VERSION"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Build wheel and sdist
+        run: uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  github-release:
+    name: Create GitHub Release (draft)
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --title "$TAG" \
+            --draft \
+            dist/*
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: github-release
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Closes #23.

`v*` タグ push をトリガーに、GitHub Release（ドラフト）の作成と PyPI 公開を自動化します。

## ワークフロー構成

**ファイル**: `.github/workflows/release.yml`

```
build ──→ github-release ──→ pypi-publish
```

| Job | 内容 | 権限 |
|-----|------|------|
| `build` | バージョン検証 → `uv build` → artifact upload | デフォルト |
| `github-release` | draft release 作成 + dist/* をアセット添付 | `contents: write` |
| `pypi-publish` | PyPI OIDC 公開 | `id-token: write` |

### バージョン検証

タグ名（`v` プレフィックス除去）と `pyproject.toml` の `version` が一致しない場合は即 abort:

```
::error::Version mismatch: tag=0.6.0, pyproject.toml=0.5.0
```

### OIDC 認証

`environment: pypi` + `permissions: id-token: write` + `pypa/gh-action-pypi-publish` の組み合わせで、API トークン不要の Trusted Publisher 認証を使用。

## マージ後に必要な手動作業

### 1. GitHub — `pypi` Environment の作成

リポジトリの **Settings → Environments → New environment** で `pypi` を作成してください。

### 2. PyPI — Trusted Publisher の登録

[https://pypi.org/manage/account/publishing/](https://pypi.org/manage/account/publishing/) で以下を登録してください:

| 項目 | 値 |
|------|-----|
| PyPI project name | `papycli` |
| Owner | `tmonj1` |
| Repository | `papycli` |
| Workflow filename | `release.yml` |
| Environment | `pypi` |

## 使い方

```bash
# pyproject.toml のバージョンを上げてコミット後:
git tag v0.6.0
git push --tags
# → ワークフローが起動し、ドラフトリリース作成 → PyPI 公開
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)