### PR TITLE
feat(completion): add tab completion for summary command

### DIFF
--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -149,7 +149,7 @@ def completions_for_context(
             if "--csv".startswith(incomplete):
                 candidates.append("--csv")
             return candidates
-        if current == 3 and words[2] != "--csv":
+        if current == 3 and (len(words) <= 2 or words[2] != "--csv"):
             return ["--csv"] if "--csv".startswith(incomplete) else []
         return []
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -156,13 +156,6 @@ def test_complete_config_no_further_completion() -> None:
     assert result == []
 
 
-def test_complete_resource_non_method_command() -> None:
-    # "summary" はリソースパスと --csv を補完候補として提示する
-    result = ctx(["papycli", "summary", ""], 2)
-    assert "/pet/findByStatus" in result
-    assert "--csv" in result
-
-
 # ---------------------------------------------------------------------------
 # summary コマンド補完
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #29

## 問題

`papycli summary <TAB>` で `--csv` もリソースパスも候補として表示されなかった。

## 原因

`completions_for_context` の `words[1] not in METHODS` チェックが `summary` にも適用され、即 `return []` していた。

## 修正内容

`config` 分岐の後、`METHODS` チェックの前に `summary` 専用の分岐を追加。

| 入力 | 補完候補 |
|------|---------|
| `papycli summary <TAB>` | リソースパス一覧 + `--csv` |
| `papycli summary /pet <TAB>` | `--csv` |
| `papycli summary --csv <TAB>` | （なし） |
| apidef 未設定時 | `--csv` のみ |

## テスト

`test_completion.py` に 6 件追加、既存テスト 1 件を更新。全 96 テストがパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)