### PR TITLE
chore: GitHub Release に AI 生成リリースノートを追加する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
             exit 1
           fi
           # Collect up to 100 subject lines; exclude merge commits
-          COMMITS=$(git log "${RANGE}" --no-merges --pretty=format:"%s" | head -100)
+          # Use --max-count instead of | head to avoid SIGPIPE under set -euo pipefail
+          COMMITS=$(git log "${RANGE}" --no-merges --max-count=100 --pretty=format:"%s")
           # Use a unique delimiter to avoid collision with commit message content
           DELIM=$(uuidgen)
           {


### PR DESCRIPTION
## Summary

`v*` タグ push 時に、前回リリース以降のコミットを GitHub Models（`gpt-4o-mini`）で分類・要約し、GitHub Release のドラフト本文に自動設定する。

Closes #39

## 変更内容（`release.yml`）

### 追加した処理（`github-release` ジョブ）

| ステップ | 内容 |
|---------|------|
| `actions/checkout@v4` に `fetch-depth: 0` | full history を取得し `git log` を有効化 |
| Get previous release tag | `gh release list` で直前のリリースタグを取得 |
| Collect commits | 直前タグ〜今回タグ間のコミット subject を収集（マージコミット除外、最大 100 件） |
| Generate release notes | `actions/ai-inference@v1` で Features / Bug Fixes / Maintenance に分類・文章化（docs: / chore: は無視） |
| Write release notes to file | AI 出力を `release_notes.md` に書き出し（シェルのクォート問題を回避） |
| Create draft release | `--notes-file release_notes.md` でリリースノートを設定 |

### パーミッション追加

```yaml
permissions:
  contents: write
  models: read   # ← 追加（GitHub Models 使用に必要）
```

### PyPI 公開フローは変更なし

## Test plan

- [x] ワークフローの YAML 構文を目視確認
- [ ] `v*` タグを push してドラフトリリースにノートが生成されることを確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)