### PR TITLE
chore: リリースノートの章の順番を Features → Bug Fixes → Maintenance に固定する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
             - IGNORE commits starting with "docs:" or "chore:" — do not include them at all.
             - Rewrite each item as a concise, user-friendly bullet point (do not copy the raw commit subject verbatim).
             - Omit any section that has no entries.
+            - Always output sections in this exact order when present: ## Features, then ## Bug Fixes, then ## Maintenance.
             - Output valid Markdown only. No preamble, no explanation outside the Markdown.
           prompt: |
             Generate release notes for ${{ github.ref_name }} from the following commit messages:


### PR DESCRIPTION
## Summary

AI が生成するリリースノートの章の順番が意図しない順序になる問題を修正する。

Closes #41

## 変更内容

`release.yml` の AI system-prompt に以下のルールを追加：

```
- Always output sections in this exact order when present: ## Features, then ## Bug Fixes, then ## Maintenance.
```

## Test plan

- [x] YAML 構文を目視確認
- [ ] 次回リリース時に章の順序が Features → Bug Fixes → Maintenance になることを確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)