### PR TITLE
fix: -p オプションで integer / boolean 型の値を正しく JSON 変換する

### DIFF
--- a/src/papycli/api_call.py
+++ b/src/papycli/api_call.py
@@ -3,11 +3,11 @@
 import json
 import os
 import re
+import sys
 from collections.abc import Sequence
 from typing import Any
 
 import requests
-
 
 # ---------------------------------------------------------------------------
 # パステンプレートマッチング
@@ -68,7 +68,7 @@ def expand_path(template: str, path_params: dict[str, str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _set_or_append(obj: dict[str, Any], key: str, value: str) -> None:
+def _set_or_append(obj: dict[str, Any], key: str, value: Any) -> None:
     """dict にキーが既存なら配列に、なければ単値として設定する。"""
     if key not in obj:
         obj[key] = value
@@ -78,12 +78,47 @@ def _set_or_append(obj: dict[str, Any], key: str, value: str) -> None:
         obj[key] = [obj[key], value]
 
 
-def build_body(pairs: Sequence[tuple[str, str]]) -> dict[str, Any]:
+def _coerce_value(value: str, type_str: str, name: str) -> Any:
+    """API 定義の type に基づいて文字列値を適切な Python 型に変換する。
+
+    変換に失敗した場合は警告を出力して文字列のまま返す。
+    """
+    try:
+        if type_str == "integer":
+            return int(value)
+        if type_str == "number":
+            return float(value)
+        if type_str == "boolean":
+            if value.lower() in ("true", "1"):
+                return True
+            if value.lower() in ("false", "0"):
+                return False
+            raise ValueError(f"not a boolean value: {value!r}")
+    except (ValueError, TypeError) as e:
+        print(
+            f"Warning: cannot convert '{value}' to {type_str} for '{name}' ({e}),"
+            " sending as string",
+            file=sys.stderr,
+        )
+    return value
+
+
+def build_body(
+    pairs: Sequence[tuple[str, str]],
+    post_parameters: Sequence[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """(-p name value) ペアから JSON ボディ dict を構築する。
 
     - 同じキーを繰り返すと JSON 配列になる
     - ドット記法 (category.id) で 1 レベルのネストオブジェクトになる
+    - post_parameters が渡された場合、type フィールドに基づき値を適切な型に変換する
     """
+    type_map: dict[str, str] = (
+        {p["name"]: p.get("type", "string") for p in post_parameters}
+        if post_parameters
+        else {}
+    )
+
     result: dict[str, Any] = {}
     for name, value in pairs:
         if "." in name:
@@ -97,7 +132,9 @@ def build_body(pairs: Sequence[tuple[str, str]]) -> dict[str, Any]:
                 )
             _set_or_append(parent_obj, child, value)
         else:
-            _set_or_append(result, name, value)
+            type_str = type_map.get(name, "string")
+            coerced = _coerce_value(value, type_str, name)
+            _set_or_append(result, name, coerced)
     return result
 
 
@@ -164,8 +201,9 @@ def call_api(
     template, path_params = match
 
     ops: list[dict[str, Any]] = apidef[template]
-    if not any(op["method"] == method for op in ops):
-        available = [op["method"] for op in ops]
+    op = next((o for o in ops if o["method"] == method), None)
+    if op is None:
+        available = [o["method"] for o in ops]
         raise ValueError(
             f"Method '{method}' is not defined for '{template}'. "
             f"Available: {', '.join(available)}"
@@ -181,7 +219,7 @@ def call_api(
     if raw_body is not None:
         json_body = json.loads(raw_body)
     elif body_params:
-        json_body = build_body(body_params)
+        json_body = build_body(body_params, op.get("post_parameters"))
 
     return requests.request(
         method=method.upper(),

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -38,6 +38,9 @@ APIDEF: dict[str, Any] = {
             "post_parameters": [
                 {"name": "name", "type": "string", "required": True},
                 {"name": "status", "type": "string", "required": False},
+                {"name": "id", "type": "integer", "required": False},
+                {"name": "available", "type": "boolean", "required": False},
+                {"name": "price", "type": "number", "required": False},
             ],
         },
         {"method": "put", "query_parameters": [], "post_parameters": []},
@@ -162,6 +165,75 @@ def test_build_body_empty() -> None:
 
 
 # ---------------------------------------------------------------------------
+# build_body — 型変換
+# ---------------------------------------------------------------------------
+
+POST_PARAMS: list[dict[str, Any]] = [
+    {"name": "id", "type": "integer", "required": False},
+    {"name": "available", "type": "boolean", "required": False},
+    {"name": "price", "type": "number", "required": False},
+    {"name": "name", "type": "string", "required": True},
+]
+
+
+def test_build_body_integer_coercion() -> None:
+    result = build_body([("id", "42")], POST_PARAMS)
+    assert result == {"id": 42}
+    assert isinstance(result["id"], int)
+
+
+def test_build_body_boolean_true_word() -> None:
+    result = build_body([("available", "true")], POST_PARAMS)
+    assert result == {"available": True}
+    assert isinstance(result["available"], bool)
+
+
+def test_build_body_boolean_false_word() -> None:
+    result = build_body([("available", "false")], POST_PARAMS)
+    assert result == {"available": False}
+    assert isinstance(result["available"], bool)
+
+
+def test_build_body_boolean_one() -> None:
+    result = build_body([("available", "1")], POST_PARAMS)
+    assert result == {"available": True}
+
+
+def test_build_body_boolean_zero() -> None:
+    result = build_body([("available", "0")], POST_PARAMS)
+    assert result == {"available": False}
+
+
+def test_build_body_number_coercion() -> None:
+    result = build_body([("price", "3.14")], POST_PARAMS)
+    assert result == {"price": 3.14}
+    assert isinstance(result["price"], float)
+
+
+def test_build_body_string_unchanged() -> None:
+    result = build_body([("name", "Dog")], POST_PARAMS)
+    assert result == {"name": "Dog"}
+    assert isinstance(result["name"], str)
+
+
+def test_build_body_invalid_integer_falls_back_to_string(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = build_body([("id", "not-a-number")], POST_PARAMS)
+    assert result == {"id": "not-a-number"}
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+    assert "integer" in captured.err
+
+
+def test_build_body_no_post_params_keeps_string() -> None:
+    """post_parameters が渡されない場合は型変換しない（後方互換）。"""
+    result = build_body([("id", "42")])
+    assert result == {"id": "42"}
+    assert isinstance(result["id"], str)
+
+
+# ---------------------------------------------------------------------------
 # parse_headers
 # ---------------------------------------------------------------------------
 
@@ -283,3 +355,18 @@ def test_call_api_unknown_path() -> None:
 def test_call_api_wrong_method() -> None:
     with pytest.raises(ValueError, match="not defined"):
         call_api("patch", "/store/inventory", BASE_URL, APIDEF)
+
+
+@rsps.activate
+def test_call_api_post_integer_body_param() -> None:
+    """call_api が post_parameters の type 情報を使って整数変換する。"""
+    rsps.add(rsps.POST, f"{BASE_URL}/pet", json={"id": 1}, status=200)
+    resp = call_api(
+        "post", "/pet", BASE_URL, APIDEF,
+        body_params=[("id", "1"), ("name", "My Dog")],
+    )
+    import json as _json
+    body = _json.loads(resp.request.body)  # type: ignore[union-attr]
+    assert body["id"] == 1
+    assert isinstance(body["id"], int)
+    assert body["name"] == "My Dog"


### PR DESCRIPTION
## Summary

- `build_body()` に `post_parameters` を渡せるようにし、API 定義の `type` フィールドを使って値を適切な Python 型に変換する
  - `"integer"` → `int`
  - `"boolean"` → `bool`（`"true"` / `"1"` → `True`、`"false"` / `"0"` → `False`）
  - `"number"` → `float`
  - `"string"` / `"array"` → そのまま文字列
  - 変換失敗時は警告を stderr に出力して文字列のまま送信する
- `call_api()` が一致したオペレーションの `post_parameters` を `build_body()` に渡すよう変更
- `post_parameters` を渡さない場合は従来通りすべて文字列（後方互換）

## Test plan

- [x] `test_build_body_integer_coercion` — `-p id 1` が `{"id": 1}`（整数）になる
- [x] `test_build_body_boolean_true_word` / `test_build_body_boolean_false_word` — `true`/`false` → `True`/`False`
- [x] `test_build_body_boolean_one` / `test_build_body_boolean_zero` — `"1"`/`"0"` → `True`/`False`
- [x] `test_build_body_number_coercion` — `"3.14"` → `3.14`（float）
- [x] `test_build_body_invalid_integer_falls_back_to_string` — 変換失敗時は文字列、警告を stderr に出力
- [x] `test_build_body_no_post_params_keeps_string` — post_parameters 未指定時は文字列のまま
- [x] `test_call_api_post_integer_body_param` — call_api 経由でも整数変換される
- [x] `uv run pytest` 全 251 テスト通過
- [x] `ruff` / `mypy` クリア

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)