### PR TITLE
docs: Git Bash での MSYS_NO_PATHCONV=1 設定を README に追記する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,6 +44,17 @@ eval "$(papycli config completion-script bash)"
 eval "$(papycli config completion-script zsh)"
 ```
 
+**Git Bash（Windows）の場合：**
+
+Git Bash は MSYS のパス変換機能を持つため、`$()` コマンド置換の出力が変換されて `eval` が正しく動作しないことがあります。
+`eval` を実行する前にパス変換を無効にしてください：
+
+```bash
+# ~/.bashrc または ~/.bash_profile に追加
+export MSYS_NO_PATHCONV=1
+eval "$(papycli config completion-script bash)"
+```
+
 設定を反映するためにシェルを再起動するか `source ~/.bashrc` / `source ~/.zshrc` を実行してください。
 
 ---

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ eval "$(papycli config completion-script bash)"
 eval "$(papycli config completion-script zsh)"
 ```
 
+**Git Bash (Windows):**
+
+Git Bash uses MSYS path conversion, which can mangle the output of `$()` command substitution.
+Disable it before running the `eval` command:
+
+```bash
+# Add to ~/.bashrc or ~/.bash_profile
+export MSYS_NO_PATHCONV=1
+eval "$(papycli config completion-script bash)"
+```
+
 Restart your shell or run `source ~/.bashrc` / `source ~/.zshrc` to apply.
 
 ---


### PR DESCRIPTION
## Summary

- README.md / README.ja.md の「Enable Shell Completion」セクションに **Git Bash (Windows)** 向けの手順を追加
- Git Bash の MSYS パス変換が `$()` 置換の出力を変換して `eval` が誤動作するケースへの対処として `export MSYS_NO_PATHCONV=1` を案内

Closes #65

## Test plan

- [x] README.md の Git Bash セクションが正しくレンダリングされることを確認
- [x] README.ja.md の対応セクションが正しくレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)