### PR TITLE
feat(spec): show raw OpenAPI spec entry when resource is specified

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -202,7 +202,8 @@ papycli config log --unset                 ログを無効化する
 papycli config completion-script <bash|zsh>  シェル補完スクリプトを出力する
 
 # 確認コマンド
-papycli spec [resource]             内部 API スペックを表示する（リソースパスでフィルタ可能）
+papycli spec                        全パスの内部 API 定義（apidef 形式）を表示する
+papycli spec [resource]             指定リソースパスの OpenAPI spec エントリを表示する
 papycli spec --full                 内部に保存された OpenAPI spec 全体を JSON 形式で出力する
 papycli summary [resource]          利用可能なエンドポイントを表示する（リソースでフィルタ可能）
                                       必須パラメータは * 付き、配列パラメータは [] 付きで表示

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ papycli config log --unset                 Disable logging
 papycli config completion-script <bash|zsh>  Print a shell completion script
 
 # Inspection commands
-papycli spec [resource]             Show the raw internal API spec (filter by resource path)
+papycli spec                        Show the internal API definition (apidef) for all paths
+papycli spec [resource]             Show the raw OpenAPI spec entry for the specified resource path
 papycli spec --full                 Output the full stored OpenAPI spec (internal JSON representation)
 papycli summary [resource]          List available endpoints (filter by resource prefix)
                                       Required params marked with *, array params with []

--- a/src/papycli/main.py
+++ b/src/papycli/main.py
@@ -302,11 +302,14 @@ def cmd_summary(resource: str | None, as_csv: bool) -> None:
 @cli.command(
     "spec",
     help=h(
-        "Show the internal API definition (apidef).\n\nFilter by RESOURCE path if given.\n\n"
-        "Use --full to output the full OpenAPI spec as-is.",
-        "API スペック（内部 apidef 形式）を表示する。\n\n"
-        "RESOURCE を指定するとそのパスのエントリのみ表示する。\n\n"
-        "--full を指定すると OpenAPI spec 全体をそのまま出力する。",
+        "Show API spec information.\n\n"
+        "Without RESOURCE: show the internal API definition (apidef) for all paths.\n\n"
+        "With RESOURCE: show the raw OpenAPI spec entry for that path.\n\n"
+        "Use --full to output the full stored OpenAPI spec (JSON).",
+        "API スペック情報を表示する。\n\n"
+        "RESOURCE なし: 全パスの内部 apidef 形式を表示する。\n\n"
+        "RESOURCE あり: 指定パスの OpenAPI spec エントリを表示する。\n\n"
+        "--full を指定すると内部に保存された OpenAPI spec 全体を JSON 形式で出力する。",
     ),
 )
 @click.argument("resource", required=False, default=None)
@@ -329,23 +332,28 @@ def cmd_spec(resource: str | None, full: bool) -> None:
         click.echo(json.dumps(raw_spec, indent=2, ensure_ascii=False))
         return
 
+    if resource is not None:
+        try:
+            raw_spec = load_current_raw_spec(conf_dir)
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(1)
+        paths = raw_spec.get("paths", {})
+        match = match_path_template(resource, list(paths.keys()))
+        if match is None:
+            click.echo(f"Error: No matching path for '{resource}'", err=True)
+            sys.exit(1)
+        template, _ = match
+        click.echo(json.dumps({template: paths[template]}, indent=2, ensure_ascii=False))
+        return
+
     try:
         apidef, _ = load_current_apidef(conf_dir)
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
-    if resource is None:
-        click.echo(json.dumps(apidef, indent=2, ensure_ascii=False))
-        return
-
-    match = match_path_template(resource, list(apidef.keys()))
-    if match is None:
-        click.echo(f"Error: No matching path for '{resource}'", err=True)
-        sys.exit(1)
-
-    template, _ = match
-    click.echo(json.dumps({template: apidef[template]}, indent=2, ensure_ascii=False))
+    click.echo(json.dumps(apidef, indent=2, ensure_ascii=False))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -713,6 +713,8 @@ def test_cmd_spec_resource_exact(petstore_conf_dir: Path, monkeypatch: pytest.Mo
     assert "/pet/findByStatus" in data
     assert "/pet" not in data
     assert "/store/inventory" not in data
+    # raw spec 形式であること（HTTP メソッドがキーになっている）
+    assert "get" in data["/pet/findByStatus"]
 
 
 @pytest.mark.skipif(not PETSTORE_PATH.exists(), reason="petstore-oas3.json not found")
@@ -725,6 +727,37 @@ def test_cmd_spec_resource_via_template(
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert "/pet/{petId}" in data
+    # raw spec 形式であること（HTTP メソッドがキーになっている）
+    assert any(m in data["/pet/{petId}"] for m in ("get", "post", "put", "patch", "delete"))
+
+
+@pytest.mark.skipif(not PETSTORE_PATH.exists(), reason="petstore-oas3.json not found")
+def test_cmd_spec_resource_shows_all_methods(
+    petstore_conf_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PAPYCLI_CONF_DIR", str(petstore_conf_dir))
+    runner = CliRunner()
+    result = runner.invoke(cli, ["spec", "/pet"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "/pet" in data
+    # /pet は post と put を持つ
+    pet_ops = data["/pet"]
+    assert "post" in pet_ops or "put" in pet_ops
+
+
+def test_cmd_spec_resource_minimal(
+    tmp_path: Path, minimal_spec_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PAPYCLI_CONF_DIR", str(tmp_path))
+    runner = CliRunner()
+    runner.invoke(cli, ["config", "add", str(minimal_spec_file)])
+    result = runner.invoke(cli, ["spec", "/items"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "/items" in data
+    # raw spec 形式であること
+    assert "get" in data["/items"]
 
 
 @pytest.mark.skipif(not PETSTORE_PATH.exists(), reason="petstore-oas3.json not found")


### PR DESCRIPTION
## Summary

- `papycli spec /pet` が内部 apidef 形式ではなく、`.spec.json` の `paths["/pet"]` セクション（生の OpenAPI spec）を出力するよう変更
- `papycli spec`（リソース指定なし）は従来通り内部 apidef 形式を表示
- パステンプレートマッチング（`/pet/99` → `/pet/{petId}`）も引き続き機能する
- README.md / README.ja.md のコマンド説明を更新

Closes #71

## 変更前後の出力比較

**変更前** (`spec /pet/findByStatus`):
```json
{
  "/pet/findByStatus": [
    { "method": "get", "query_parameters": [...], "post_parameters": [] }
  ]
}
```

**変更後** (`spec /pet/findByStatus`):
```json
{
  "/pet/findByStatus": {
    "get": {
      "tags": ["pet"],
      "summary": "Finds Pets by status",
      "parameters": [...],
      "responses": {...}
    }
  }
}
```

## Test plan

- [ ] `test_cmd_spec_resource_exact` — `/pet/findByStatus` の raw spec が返ること、`get` キーを含むこと
- [ ] `test_cmd_spec_resource_via_template` — `/pet/99` → `/pet/{petId}` の raw spec が返ること
- [ ] `test_cmd_spec_resource_shows_all_methods` — `/pet` の raw spec が post/put を含むこと
- [ ] `test_cmd_spec_resource_minimal` — minimal spec で `/items` の raw spec が返ること
- [ ] `test_cmd_spec_all` — リソース指定なしは従来通り内部 apidef を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)