### PR TITLE
docs: --response-check と --full オプションをドキュメントに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ papycli/
 │       ├── config.py        # 設定ファイルの読み書き
 │       ├── i18n.py          # 日英ヘルプテキストの切り替えユーティリティ
 │       ├── request_filter.py # リクエストフィルタープラグイン機構
+│       ├── response_checker.py # --response-check のレスポンス検証
 │       ├── spec_loader.py   # OpenAPI spec の読み込み・$ref 解決
 │       └── summary.py       # summary コマンド・CSV 出力
 ├── tests/
@@ -55,6 +56,7 @@ papycli/
 │   ├── test_init_cmd.py
 │   ├── test_main.py
 │   ├── test_request_filter.py
+│   ├── test_response_checker.py
 │   ├── test_spec_loader.py
 │   └── test_summary.py
 ├── examples/
@@ -94,6 +96,9 @@ bash / zsh 向けの補完スクリプトを生成する。補完の候補はメ
 
 **`request_filter.py`** — リクエスト・レスポンスフィルタープラグイン機構
 エントリポイントグループ `papycli.request_filters` に登録されたフィルター関数をプラグイン名の昇順で呼び出し、リクエスト送信前に URL・クエリパラメータ・ボディ・ヘッダーを変換できるようにする。同様に `papycli.response_filters` グループのフィルター関数を呼び出し、レスポンス受信後にステータスコード・理由フレーズ（reason）・ボディ・ヘッダーを参照・変更できるようにする。`RequestContext` / `ResponseContext` データクラスと `load_filters()` / `apply_filters()` / `load_response_filters()` / `apply_response_filters()` 関数を提供する。
+
+**`response_checker.py`** — レスポンス検証
+`--response-check` オプション用のレスポンス検証ロジック。実際のHTTPステータスコードと OpenAPI spec に定義されたレスポンスコードを照合し、不一致の場合に警告する。また JSON レスポンスボディをスキーマに照合し、型・enum・必須フィールド・additionalProperties 等の違反を検出して警告メッセージのリストを返す。
 
 **`summary.py`** — サマリー表示
 登録済み API のエンドポイント一覧を整形して出力する。`--summary-csv` では CSV 形式で出力する。
@@ -169,6 +174,7 @@ papycli config list
 papycli config log [PATH] [--unset]
 papycli config completion-script <bash|zsh>
 papycli spec [resource]
+papycli spec --full [resource]
 papycli summary [resource] [--csv]
 papycli --version
 papycli --help / -h
@@ -187,6 +193,7 @@ papycli --help / -h
 - `-H <header: value>` — カスタム HTTP ヘッダー
 - `--check` — 送信前にパラメータを検証する（警告を stderr に出力、リクエストは送信）
 - `--check-strict` — 送信前にパラメータを検証する（警告を stderr に出力、問題があればリクエスト中止・exit 1）
+- `--response-check` — レスポンスのステータスコードとボディを OpenAPI spec に照合する（違反は stderr に出力、exit code には影響しない）
 
 ### パステンプレートのマッチング
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,7 @@
 - 複数 API の登録・切り替え
 - `papycli spec` による API スペックの確認
 - `--check` / `--check-strict` によるリクエスト前のパラメータ検証
+- `--response-check` による OpenAPI spec に基づくレスポンスのステータスコード・ボディ検証
 - API 仕様に基づいて `-p` の値を適切な JSON 型（integer / number / boolean）に自動変換
 - `papycli config log` によるリクエスト/レスポンスのファイルログ
 - リクエストフィルタープラグイン（`papycli.request_filters` エントリポイント）によるリクエスト処理の拡張
@@ -120,7 +121,7 @@ $ papycli get <TAB>
   /pet/findByStatus  /pet/{petId}  /store/inventory  ...
 
 $ papycli get /pet/findByStatus <TAB>
-  -q  -p  -H  -d  --summary  --verbose  --check  --check-strict
+  -q  -p  -H  -d  --summary  --verbose  --check  --check-strict  --response-check
 
 $ papycli get /pet/findByStatus -q <TAB>
   status
@@ -232,6 +233,8 @@ papycli <method> <resource> [options]
   --summary               リクエストを送らずにエンドポイント情報を表示する
   --check                 送信前にパラメータを検証する（警告を stderr に出力、リクエストは送信）
   --check-strict          送信前にパラメータを検証する（警告を stderr に出力、問題があればリクエスト中止・exit 1）
+  --response-check        レスポンスのステータスコードとボディを OpenAPI spec に照合する
+                            （違反は stderr に出力、exit code には影響しない）
   --verbose / -v          HTTP ステータス行を表示する
   --version               バージョンを表示する
   --help / -h             使い方を表示する

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Register and switch between multiple APIs
 - Inspect API specs with `papycli spec`
 - Validate request parameters before sending with `--check` / `--check-strict`
+- Validate response body and status code against the OpenAPI spec with `--response-check`
 - Automatically coerces `-p` values to the correct JSON type (integer, number, boolean) based on the API spec
 - Log requests and responses to a file with `papycli config log`
 - Extend request processing with request filter plugins (`papycli.request_filters` entry point)
@@ -120,7 +121,7 @@ $ papycli get <TAB>
   /pet/findByStatus  /pet/{petId}  /store/inventory  ...
 
 $ papycli get /pet/findByStatus <TAB>
-  -q  -p  -H  -d  --summary  --verbose  --check  --check-strict
+  -q  -p  -H  -d  --summary  --verbose  --check  --check-strict  --response-check
 
 $ papycli get /pet/findByStatus -q <TAB>
   status
@@ -233,6 +234,8 @@ Options:
   --summary               Show endpoint info without sending a request
   --check                 Validate params before sending (warn on stderr, request is still sent)
   --check-strict          Validate params before sending (warn on stderr, abort with exit 1 on failure)
+  --response-check        Validate response status code and body against the OpenAPI spec
+                            (warn on stderr; violations do not affect exit code)
   --verbose / -v          Show HTTP status line
   --version               Show version
   --help / -h             Show help

--- a/design_doc.md
+++ b/design_doc.md
@@ -292,6 +292,46 @@ my-filter = "my_plugin:request_filter"
 
 ---
 
+### Milestone 8 — `spec --full` とレスポンスフィルタープラグイン機構
+
+**目的**: `papycli spec --full` で生の OpenAPI spec を表示できるようにする。また response filter プラグインによりレスポンスの参照・変換を可能にする。
+
+**実装内容**:
+- `main.py` に `papycli spec --full [resource]` サブコマンドを追加
+  - 内部変換後の API 定義ではなく、元の OpenAPI spec を JSON で出力する
+  - `resource` 指定時は該当パスのみ絞り込んで表示する
+- `request_filter.py` にレスポンスフィルター機構を追加
+  - `ResponseContext` データクラス（`status_code`, `reason`, `body`, `headers`）
+  - `load_response_filters()`: `papycli.response_filters` エントリポイントグループからフィルターをロード
+  - `apply_response_filters()`: フィルターを順番に適用。例外・戻り値不正の場合は警告して前の ctx を維持する
+- `api_call.py` でレスポンス受信後にフィルターを適用するよう更新
+
+**完了条件**: `papycli spec --full` で生の OpenAPI spec が出力される。`papycli.response_filters` エントリポイントに登録したフィルターがレスポンス受信後に自動適用される。テストがパスする。
+
+---
+
+### Milestone 9 — `--response-check` レスポンス検証
+
+**目的**: `--response-check` オプションを追加し、実際のレスポンスを OpenAPI spec に照合して違反を警告できるようにする。
+
+**実装内容**:
+- `response_checker.py`
+  - `check_response()`: レスポンスのステータスコードとボディを spec に照合し、違反メッセージのリストを返す
+    - ステータスコード照合: exact match (`"200"`) → 範囲指定 (`"2XX"`, `"2xx"`) → `"default"` の順で探索。どれにも一致しない場合に警告する
+    - ボディスキーマ照合: `application/json` および `+json` サフィックスのメディアタイプに対して実施。型・enum・必須フィールド・additionalProperties・配列 items を再帰的に検証する
+    - スキーマ存在確認を先に行い、スキーマが定義されていない場合はボディパースをスキップする（204 等での誤警告防止）
+    - YAML 由来の整数キー（`200:` → `200`）を文字列に正規化してから照合する
+  - `_check_value()`: 値とスキーマを再帰的に照合するヘルパー
+    - union type（`type: ["object", "null"]`）・type 省略スキーマ（`properties`/`items` から推論）をサポート
+    - 不正なスキーマ形状（`properties` が非 dict 等）に対して型ガードを設けクラッシュを防止する
+- `main.py` に `--response-check` フラグを追加
+- `api_call.py` の `call_api()` で response filter 適用前に `check_response()` を呼び出す
+- テスト: `test_response_checker.py`、`test_main.py`
+
+**完了条件**: `papycli get /pet/1 --response-check` で spec と一致しないレスポンスが返された場合に stderr へ警告が出力される。ステータスコード不一致・ボディスキーマ違反ともに検出される。テストがパスする。
+
+---
+
 ## 開発上の方針
 
 ### ブランチ・コミット戦略


### PR DESCRIPTION
Closes #81

## Summary

- **README.md / README.ja.md**: Features 欄・タブ補完例・Reference セクションに `--response-check` を追記
- **CLAUDE.md**: `response_checker.py` / `test_response_checker.py` をディレクトリ構成と主要モジュールに追記、`spec --full` と `--response-check` を CLI 仕様に追記
- **design_doc.md**: Milestone 8（`spec --full` / response filter プラグイン）と Milestone 9（`--response-check` レスポンス検証）を追加

## Test plan

- [x] README.md / README.ja.md の記述内容が実装と一致していることを確認
- [x] CLAUDE.md のディレクトリ構成・CLI 仕様が実装と一致していることを確認
- [x] design_doc.md の Milestone 8 / 9 の内容が実装と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)