### PR TITLE
refactor: request_filter.py を filters.py にリネームし定数名を対称化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ papycli/
 │       ├── completion.py    # シェル補完スクリプト生成
 │       ├── config.py        # 設定ファイルの読み書き
 │       ├── i18n.py          # 日英ヘルプテキストの切り替えユーティリティ
-│       ├── request_filter.py # リクエストフィルタープラグイン機構
+│       ├── filters.py        # リクエスト・レスポンスフィルタープラグイン機構
 │       ├── response_checker.py # --response-check のレスポンス検証
 │       ├── spec_loader.py   # OpenAPI spec の読み込み・$ref 解決
 │       └── summary.py       # summary コマンド・CSV 出力
@@ -55,7 +55,7 @@ papycli/
 │   ├── test_i18n.py
 │   ├── test_init_cmd.py
 │   ├── test_main.py
-│   ├── test_request_filter.py
+│   ├── test_filters.py
 │   ├── test_response_checker.py
 │   ├── test_spec_loader.py
 │   └── test_summary.py
@@ -94,7 +94,7 @@ bash / zsh 向けの補完スクリプトを生成する。補完の候補はメ
 **`config.py`** — 設定管理
 `papycli.conf` の読み書きと、`PAPYCLI_CONF_DIR` 環境変数の解決を行う。ログファイルパスの取得・設定・削除も担当する。
 
-**`request_filter.py`** — リクエスト・レスポンスフィルタープラグイン機構
+**`filters.py`** — リクエスト・レスポンスフィルタープラグイン機構
 エントリポイントグループ `papycli.request_filters` に登録されたフィルター関数をプラグイン名の昇順で呼び出し、リクエスト送信前に URL・クエリパラメータ・ボディ・ヘッダーを変換できるようにする。同様に `papycli.response_filters` グループのフィルター関数を呼び出し、レスポンス受信後にステータスコード・理由フレーズ（reason）・ボディ・ヘッダーを参照・変更できるようにする。`RequestContext` / `ResponseContext` データクラスと `load_filters()` / `apply_filters()` / `load_response_filters()` / `apply_response_filters()` 関数を提供する。
 
 **`response_checker.py`** — レスポンス検証

--- a/examples/request_filter/src/papycli_debug_filter/__init__.py
+++ b/examples/request_filter/src/papycli_debug_filter/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import sys
 
-from papycli.request_filter import RequestContext
+from papycli.filters import RequestContext
 
 
 def _to_json(value: object) -> str:

--- a/examples/response_filter/src/papycli_debug_response_filter/__init__.py
+++ b/examples/response_filter/src/papycli_debug_response_filter/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import sys
 
-from papycli.request_filter import ResponseContext
+from papycli.filters import ResponseContext
 
 
 def _to_json(value: object) -> str:

--- a/src/papycli/api_call.py
+++ b/src/papycli/api_call.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from papycli.request_filter import RequestContext
+    from papycli.filters import RequestContext
 
 import requests
 
@@ -315,7 +315,7 @@ def call_api(
     do_response_check: bool = False,
 ) -> requests.Response:
     """API を呼び出し、レスポンスを返す。"""
-    from papycli.request_filter import (
+    from papycli.filters import (
         RequestContext,
         ResponseContext,
         apply_filters,

--- a/src/papycli/filters.py
+++ b/src/papycli/filters.py
@@ -29,7 +29,7 @@ import sys
 from dataclasses import dataclass, field
 from typing import Any, Callable, TypeAlias
 
-ENTRY_POINT_GROUP = "papycli.request_filters"
+REQUEST_ENTRY_POINT_GROUP = "papycli.request_filters"
 RESPONSE_ENTRY_POINT_GROUP = "papycli.response_filters"
 
 JsonValue: TypeAlias = dict[str, Any] | list[Any] | str | int | float | bool | None
@@ -74,7 +74,7 @@ def load_filters() -> list[tuple[str, FilterFunc]]:
 
     ロードに失敗したプラグインは警告を出力してスキップする。
     """
-    eps = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+    eps = importlib.metadata.entry_points(group=REQUEST_ENTRY_POINT_GROUP)
     result: list[tuple[str, FilterFunc]] = []
     for ep in sorted(eps, key=lambda e: e.name):
         try:
@@ -88,7 +88,7 @@ def load_filters() -> list[tuple[str, FilterFunc]]:
         if not callable(func):
             print(
                 f"Warning: entry point '{ep.name}' for group"
-                f" '{ENTRY_POINT_GROUP}' is not callable and will be ignored.",
+                f" '{REQUEST_ENTRY_POINT_GROUP}' is not callable and will be ignored.",
                 file=sys.stderr,
             )
             continue

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -517,7 +517,7 @@ def test_call_api_log_uses_pre_filter_values(tmp_path: Path) -> None:
     """ログの先頭セクションにはフィルター適用前の URL・クエリ・ボディが記録される。"""
     from unittest.mock import patch
 
-    from papycli.request_filter import RequestContext
+    from papycli.filters import RequestContext
 
     rsps.add(rsps.GET, f"{BASE_URL}/store/inventory", json={}, status=200)
     logfile = str(tmp_path / "test.log")
@@ -532,7 +532,7 @@ def test_call_api_log_uses_pre_filter_values(tmp_path: Path) -> None:
         )
 
     with patch(
-        "papycli.request_filter.load_filters",
+        "papycli.filters.load_filters",
         return_value=[("mutating", mutating_filter)],
     ):
         call_api("get", "/store/inventory", BASE_URL, APIDEF, logfile=logfile)
@@ -549,7 +549,7 @@ def test_call_api_log_includes_filtered_section_when_filter_applied(tmp_path: Pa
     """フィルターが 1 件以上適用された場合、Filtered-* セクションがログに追記される。"""
     from unittest.mock import patch
 
-    from papycli.request_filter import RequestContext
+    from papycli.filters import RequestContext
 
     rsps.add(rsps.GET, f"{BASE_URL}/store/inventory", json={}, status=200)
     logfile = str(tmp_path / "test.log")
@@ -564,7 +564,7 @@ def test_call_api_log_includes_filtered_section_when_filter_applied(tmp_path: Pa
         )
 
     with patch(
-        "papycli.request_filter.load_filters",
+        "papycli.filters.load_filters",
         return_value=[("mutating", mutating_filter)],
     ):
         call_api("get", "/store/inventory", BASE_URL, APIDEF, logfile=logfile)
@@ -593,7 +593,7 @@ def test_call_api_log_no_filtered_section_without_filters(tmp_path: Path) -> Non
     rsps.add(rsps.GET, f"{BASE_URL}/store/inventory", json={}, status=200)
     logfile = str(tmp_path / "test.log")
 
-    with patch("papycli.request_filter.load_filters", return_value=[]):
+    with patch("papycli.filters.load_filters", return_value=[]):
         call_api("get", "/store/inventory", BASE_URL, APIDEF, logfile=logfile)
 
     content = Path(logfile).read_text(encoding="utf-8")
@@ -605,7 +605,7 @@ def test_call_api_log_filtered_headers_masks_sensitive_values(tmp_path: Path) ->
     """フィルターが機密ヘッダーを追加した場合、Filtered-Headers でマスクされる。"""
     from unittest.mock import patch
 
-    from papycli.request_filter import RequestContext
+    from papycli.filters import RequestContext
 
     rsps.add(rsps.GET, f"{BASE_URL}/store/inventory", json={}, status=200)
     logfile = str(tmp_path / "test.log")
@@ -620,7 +620,7 @@ def test_call_api_log_filtered_headers_masks_sensitive_values(tmp_path: Path) ->
         )
 
     with patch(
-        "papycli.request_filter.load_filters",
+        "papycli.filters.load_filters",
         return_value=[("auth", auth_adding_filter)],
     ):
         call_api("get", "/store/inventory", BASE_URL, APIDEF, logfile=logfile)
@@ -638,7 +638,7 @@ def test_call_api_log_filtered_section_unserializable_fallback(tmp_path: Path) -
     """フィルター後の値が直列化不可でも、先頭セクションとレスポンスはログに書かれる。"""
     from unittest.mock import patch
 
-    from papycli.request_filter import RequestContext
+    from papycli.filters import RequestContext
 
     rsps.add(rsps.GET, f"{BASE_URL}/store/inventory", json={"ok": 1}, status=200)
     logfile = str(tmp_path / "test.log")
@@ -649,7 +649,7 @@ def test_call_api_log_filtered_section_unserializable_fallback(tmp_path: Path) -
     # _format_query_str の 2 回目の呼び出し（filtered セクション用）だけ例外を送出させる
     with (
         patch(
-            "papycli.request_filter.load_filters",
+            "papycli.filters.load_filters",
             return_value=[("noop", noop_filter)],
         ),
         patch(
@@ -674,7 +674,7 @@ def test_call_api_log_filtered_section_unserializable_emits_warning(
     """フィルター後の値が直列化不可の場合、警告を stderr に出力する。"""
     from unittest.mock import patch
 
-    from papycli.request_filter import RequestContext
+    from papycli.filters import RequestContext
 
     rsps.add(rsps.GET, f"{BASE_URL}/store/inventory", json={}, status=200)
     logfile = str(tmp_path / "test.log")
@@ -684,7 +684,7 @@ def test_call_api_log_filtered_section_unserializable_emits_warning(
 
     with (
         patch(
-            "papycli.request_filter.load_filters",
+            "papycli.filters.load_filters",
             return_value=[("noop", noop_filter)],
         ),
         patch(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-"""request_filter モジュールのテスト."""
+"""filters モジュールのテスト."""
 
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -7,7 +7,7 @@ import pytest
 import responses as rsps
 
 from papycli.api_call import call_api
-from papycli.request_filter import (
+from papycli.filters import (
     RequestContext,
     ResponseContext,
     apply_filters,
@@ -205,7 +205,7 @@ def _make_ep(name: str, func: Any) -> MagicMock:
 
 
 def test_load_filters_empty() -> None:
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[]):
         result = load_filters()
     assert result == []
 
@@ -216,7 +216,7 @@ def test_load_filters_sorted_by_name() -> None:
         _make_ep("a-filter", _modify_url_filter),
         _make_ep("m-filter", _add_query_filter),
     ]
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=eps):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=eps):
         result = load_filters()
     names = [name for name, _ in result]
     assert names == ["a-filter", "m-filter", "z-filter"]
@@ -229,7 +229,7 @@ def test_load_filters_skips_failing_load(capsys: pytest.CaptureFixture[str]) -> 
     good_ep = _make_ep("good-plugin", _add_header_filter)
 
     with patch(
-        "papycli.request_filter.importlib.metadata.entry_points",
+        "papycli.filters.importlib.metadata.entry_points",
         return_value=[bad_ep, good_ep],
     ):
         result = load_filters()
@@ -250,7 +250,7 @@ def test_load_filters_skips_non_callable(capsys: pytest.CaptureFixture[str]) -> 
     good_ep = _make_ep("good-plugin", _add_header_filter)
 
     with patch(
-        "papycli.request_filter.importlib.metadata.entry_points",
+        "papycli.filters.importlib.metadata.entry_points",
         return_value=[bad_ep, good_ep],
     ):
         result = load_filters()
@@ -294,7 +294,7 @@ def test_call_api_filter_adds_header() -> None:
         return ctx
 
     ep = _make_ep("h-filter", inject_header)
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[ep]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[ep]):
         resp = call_api("get", "/store/inventory", BASE_URL, APIDEF)
 
     assert resp.request.headers["X-Filter"] == "injected"  # type: ignore[union-attr]
@@ -310,7 +310,7 @@ def test_call_api_filter_modifies_query_params() -> None:
         return ctx
 
     ep = _make_ep("q-filter", inject_query)
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[ep]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[ep]):
         resp = call_api("get", "/store/inventory", BASE_URL, APIDEF)
 
     assert "token=abc" in resp.request.url  # type: ignore[union-attr]
@@ -321,7 +321,7 @@ def test_call_api_no_filters() -> None:
     """フィルターが 0 件のときも通常通りリクエストが送信される。"""
     rsps.add(rsps.GET, f"{BASE_URL}/store/inventory", json={"dogs": 1}, status=200)
 
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[]):
         resp = call_api("get", "/store/inventory", BASE_URL, APIDEF)
 
     assert resp.status_code == 200
@@ -371,7 +371,7 @@ def test_response_context_request_body() -> None:
 
 
 def test_load_response_filters_empty() -> None:
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[]):
         result = load_response_filters()
     assert result == []
 
@@ -380,7 +380,7 @@ def test_load_response_filters_load_error_skipped(capsys: pytest.CaptureFixture[
     ep = MagicMock()
     ep.name = "bad-filter"
     ep.load.side_effect = ImportError("missing module")
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[ep]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[ep]):
         result = load_response_filters()
     assert result == []
     assert "Warning" in capsys.readouterr().err
@@ -390,7 +390,7 @@ def test_load_response_filters_skips_non_callable(capsys: pytest.CaptureFixture[
     ep = MagicMock()
     ep.name = "non-callable"
     ep.load.return_value = "not a function"
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[ep]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[ep]):
         result = load_response_filters()
     assert result == []
     assert "Warning" in capsys.readouterr().err
@@ -410,7 +410,7 @@ def test_load_response_filters_sorted_by_name() -> None:
     ep2.name = "a-filter"
     ep2.load.return_value = f2
 
-    with patch("papycli.request_filter.importlib.metadata.entry_points", return_value=[ep1, ep2]):
+    with patch("papycli.filters.importlib.metadata.entry_points", return_value=[ep1, ep2]):
         result = load_response_filters()
 
     assert [name for name, _ in result] == ["a-filter", "z-filter"]
@@ -574,7 +574,7 @@ APIDEF_RF: dict[str, Any] = {
 @pytest.fixture(autouse=False)
 def no_request_filters() -> Any:
     """call_api integration tests: リクエストフィルターを空にして hermetic にする。"""
-    with patch("papycli.request_filter.load_filters", return_value=[]):
+    with patch("papycli.filters.load_filters", return_value=[]):
         yield
 
 
@@ -588,7 +588,7 @@ def test_call_api_response_filter_modifies_body(no_request_filters: Any) -> None
         ctx.body["cats"] = 99
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("add-cats", add_cats)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("add-cats", add_cats)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert resp.json() == {"dogs": 1, "cats": 99}
@@ -604,7 +604,7 @@ def test_call_api_response_filter_receives_correct_context(no_request_filters: A
         received.append(ctx)
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("capture", capture)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("capture", capture)]):
         call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert len(received) == 1
@@ -626,7 +626,7 @@ def test_call_api_response_filter_receives_request_body(no_request_filters: Any)
         received.append(ctx)
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("capture", capture)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("capture", capture)]):
         call_api("post", "/pet", BASE_URL_RF, APIDEF_RF, body_params=[("name", "Fido")])
 
     assert len(received) == 1
@@ -642,7 +642,7 @@ def test_call_api_response_filter_body_set_to_none(no_request_filters: Any) -> N
         ctx.body = None
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("clear", clear_body)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("clear", clear_body)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert resp.content == b""
@@ -653,7 +653,7 @@ def test_call_api_response_filter_no_filters_unchanged(no_request_filters: Any) 
     """レスポンスフィルターが 0 件のとき、レスポンスは変更されない。"""
     rsps.add(rsps.GET, f"{BASE_URL_RF}/store/inventory", json={"dogs": 1}, status=200)
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[]):
+    with patch("papycli.filters.load_response_filters", return_value=[]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert resp.json() == {"dogs": 1}
@@ -669,7 +669,7 @@ def test_call_api_response_filter_noop_body_not_rewritten(no_request_filters: An
         ctx.body = {"dogs": 1}
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("noop", noop)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("noop", noop)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     # モックが返した元のレスポンスボディ（生バイト列）
@@ -689,7 +689,7 @@ def test_call_api_response_filter_modifies_status_code(no_request_filters: Any) 
         ctx.status_code = 201
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("s", change_status)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("s", change_status)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert resp.status_code == 201
@@ -704,7 +704,7 @@ def test_call_api_response_filter_modifies_reason(no_request_filters: Any) -> No
         ctx.reason = "Custom Reason"
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("r", change_reason)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("r", change_reason)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert resp.reason == "Custom Reason"
@@ -719,7 +719,7 @@ def test_call_api_response_filter_modifies_headers(no_request_filters: Any) -> N
         ctx.headers["X-Custom"] = "value"
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("h", add_header)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("h", add_header)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert resp.headers["X-Custom"] == "value"
@@ -739,7 +739,7 @@ def test_call_api_response_filter_non_serializable_body_warns(
         ctx.body = {"ts": datetime.datetime.now()}  # not JSON-serializable
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("b", bad_body)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("b", bad_body)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     original_content = rsps.calls[0].response.content
@@ -761,7 +761,7 @@ def test_call_api_response_filter_circular_ref_body_warns(
         ctx.body = d
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("c", circular_body)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("c", circular_body)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     original_content = rsps.calls[0].response.content
@@ -785,7 +785,7 @@ def test_call_api_response_filter_updates_content_type_charset(no_request_filter
         ctx.body["cats"] = 99
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("a", add_key)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("a", add_key)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert "charset=utf-8" in resp.headers.get("Content-Type", "")
@@ -808,7 +808,7 @@ def test_call_api_response_filter_replaces_existing_charset(no_request_filters: 
         ctx.body["cats"] = 99
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("a", add_key)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("a", add_key)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     ct = resp.headers.get("Content-Type", "")
@@ -827,7 +827,7 @@ def test_call_api_response_filter_updates_content_length(no_request_filters: Any
         ctx.body["cats"] = 99
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("a", add_key)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("a", add_key)]):
         resp = call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     expected_len = len(resp.content)
@@ -850,7 +850,7 @@ def test_call_api_response_filter_case_insensitive_content_type(no_request_filte
         received.append(ctx)
         return ctx
 
-    with patch("papycli.request_filter.load_response_filters", return_value=[("c", capture)]):
+    with patch("papycli.filters.load_response_filters", return_value=[("c", capture)]):
         call_api("get", "/store/inventory", BASE_URL_RF, APIDEF_RF)
 
     assert received[0].body == {"dogs": 1}


### PR DESCRIPTION
Closes #86

## Summary

- `src/papycli/request_filter.py` → `src/papycli/filters.py` にリネーム（request/response 両フィルターを含むため）
- `ENTRY_POINT_GROUP` → `REQUEST_ENTRY_POINT_GROUP` にリネーム（`RESPONSE_ENTRY_POINT_GROUP` との対称性を確保）
- `api_call.py`、`tests/test_filters.py`、`tests/test_api_call.py`、examples の import パスを `papycli.request_filter` → `papycli.filters` に更新
- `CLAUDE.md` のアーキテクチャ説明も合わせて更新

## Test plan

- [x] `uv run pytest tests/test_filters.py tests/test_api_call.py` — 110 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)