### PR TITLE
chore: PR 作成時に Copilot レビューを自動リクエストするワークフローを追加

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -8,6 +8,11 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  # 同一PRの実行を直列化し TOCTOU を防ぐ。後発ジョブは前の完了を待つ。
+  group: copilot-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   request-copilot-review:
     runs-on: ubuntu-latest
@@ -21,6 +26,7 @@ jobs:
           PR="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
           # 既にレビュー依頼済みの場合は追加しない（冪等性の確保）
+          # concurrency で直列化済みだが、念のため確認してからリクエストする
           REVIEWERS=$(gh pr view "$PR" --repo "$REPO" \
             --json reviewRequests \
             --jq '[.reviewRequests[].login] | join(" ")')


### PR DESCRIPTION
Closes #88

## Summary

- `.github/workflows/copilot-review.yml` を新規追加
- `pull_request_target` の `opened` / `reopened` / `synchronize` をトリガーに、`copilot-pull-request-reviewer` をレビュアーとして自動追加する
- `pull_request` ではなく `pull_request_target` を使用する理由: フォーク PR では `pull_request` イベントの `GITHUB_TOKEN` が読み取り専用になり `--add-reviewer` が失敗するため。このワークフローは PR コードをチェックアウト・実行しないので `pull_request_target` を使っても安全

## Test plan

- [ ] 次のPRで Copilot レビューが自動リクエストされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)