### PR TITLE
fix: synchronize 後も Copilot レビューを確実に再リクエストする

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -30,26 +30,29 @@ jobs:
           # この状態で --add-reviewer だけを呼ぶと 422 が返り新たなイベントが発行されない。
           # 一度 remove してから add することで Copilot のレビューを確実に再起動する。
 
-          # remove: Copilot がリクエストされていない場合（opened 直後等）は 422 が返るが無視する。
-          # それ以外のエラー（認証失敗・権限不足等）はジョブを失敗させる。
+          # remove: Copilot がリクエストされていない場合（opened 直後等）は
+          # "HTTP 422" かつ "not a requested reviewer" が返るが無視する。
+          # それ以外のエラー（他の 422・認証失敗・権限不足等）はジョブを失敗させる。
           if ! err=$(gh pr edit "$PR" --repo "$REPO" \
             --remove-reviewer "copilot-pull-request-reviewer" 2>&1); then
-            if echo "$err" | grep -q "422"; then
+            if printf '%s' "$err" | grep -q "HTTP 422" && \
+               printf '%s' "$err" | grep -qi "not a requested reviewer"; then
               echo "Copilot was not a requested reviewer; continuing." >&2
             else
-              echo "$err" >&2
+              printf '%s\n' "$err" >&2
               exit 1
             fi
           fi
 
-          # add: Copilot がすでにレビュー待ちの場合（422 + "already"）は無視する。
-          # それ以外のエラー（認証失敗・権限不足・設定ミス等）はジョブを失敗させる。
+          # add: Copilot がすでにレビュー待ちの場合（"HTTP 422" + "already"）は無視する。
+          # それ以外のエラー（他の 422・認証失敗・権限不足・設定ミス等）はジョブを失敗させる。
           if ! err=$(gh pr edit "$PR" --repo "$REPO" \
             --add-reviewer "copilot-pull-request-reviewer" 2>&1); then
-            if echo "$err" | grep -q "422" && echo "$err" | grep -qi "already"; then
+            if printf '%s' "$err" | grep -q "HTTP 422" && \
+               printf '%s' "$err" | grep -qi "already"; then
               echo "Copilot is already pending review; skipping re-request." >&2
             else
-              echo "$err" >&2
+              printf '%s\n' "$err" >&2
               exit 1
             fi
           fi


### PR DESCRIPTION
## Summary

Closes #91

- コミット追加（`synchronize`）後、GitHub は保留中レビューを dismissed にするが `reviewRequests` からは削除しない
- 既存の冪等性チェック（`reviewRequests` に Copilot が含まれるか確認）が常に true となり、`--add-reviewer` がスキップされていた
- チェックを削除し、常に `--add-reviewer` を実行するよう修正
- Copilot がすでにレビュー待ち中の場合に返る 422 は `|| true` で無視する

## Test plan

- [ ] PR を作成し、Copilot のレビューが自動リクエストされることを確認
- [ ] 追加コミットをプッシュし、Copilot のレビューが再度リクエストされることを確認
- [ ] PR を close → reopen し、Copilot のレビューが再リクエストされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)