### PR TITLE
feat: 必須パラメータを先頭に表示し * を付ける（-p / -q 補完）

### DIFF
--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -89,7 +89,7 @@ def _used_param_names(words: list[str], flag: str) -> set[str]:
             # NAME が別のオプションフラグでも空文字でもない場合のみ使用済みとして扱う
             # 補完で選択された場合に末尾に * が付いていることがあるため取り除いてから登録する
             if name and not name.startswith("-"):
-                used.add(name.rstrip("*"))
+                used.add(name.removesuffix("*"))
             # flag と NAME までは確実に読み飛ばすが、VALUE は仮定しない
             i += 2
         else:
@@ -110,7 +110,7 @@ def _complete_param_names(
         return []
     key = "query_parameters" if kind == "query" else "post_parameters"
     # incomplete の末尾 * を取り除いてからパラメータ名と比較する
-    incomplete_stripped = incomplete.rstrip("*")
+    incomplete_stripped = incomplete.removesuffix("*")
     required: list[str] = []
     optional: list[str] = []
     for p in op.get(key, []):
@@ -139,7 +139,7 @@ def _complete_enum_values(
         return []
     key = "query_parameters" if kind == "query" else "post_parameters"
     # 補完で選択された場合、param_name の末尾に * が付いていることがあるため取り除く
-    normalized_name = param_name.rstrip("*")
+    normalized_name = param_name.removesuffix("*")
     for p in op.get(key, []):
         if p["name"] == normalized_name and "enum" in p:
             return [str(v) for v in p["enum"] if str(v).startswith(incomplete)]

--- a/src/papycli/main.py
+++ b/src/papycli/main.py
@@ -459,6 +459,10 @@ def _api_command(method: str) -> click.Command:
             click.echo("Error: --check and --check-strict cannot be used together.", err=True)
             sys.exit(1)
 
+        # 補完で選択された際に末尾に * が付いたパラメータ名（例: "name*"）を正規化する。
+        query_params = tuple((n.removesuffix("*"), v) for n, v in query_params)
+        body_params = tuple((n.removesuffix("*"), v) for n, v in body_params)
+
         # リソースに "?" が含まれる場合、クエリ文字列を分離してクエリパラメータに追加する。
         # 例: /pet/findByStatus?status=available
         #   → resource=/pet/findByStatus,

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -38,6 +38,16 @@ APIDEF: dict[str, Any] = {
             "post_parameters": [],
         }
     ],
+    "/pet/findByTags": [
+        {
+            "method": "get",
+            "query_parameters": [
+                {"name": "tags", "type": "array", "required": True},
+                {"name": "limit", "type": "integer", "required": False},
+            ],
+            "post_parameters": [],
+        }
+    ],
     "/pet/{petId}": [
         {"method": "get", "query_parameters": [], "post_parameters": []},
         {"method": "delete", "query_parameters": [], "post_parameters": []},
@@ -264,6 +274,31 @@ def test_complete_query_param_repeated_option() -> None:
     assert "status" not in result
 
 
+def test_complete_query_param_name_required_asterisk() -> None:
+    """必須クエリパラメータは * 付きで返され先頭に並ぶ。"""
+    words = ["papycli", "get", "/pet/findByTags", "-q", ""]
+    result = ctx(words, 4)
+    assert "tags*" in result
+    assert "limit" in result
+    assert result.index("tags*") < result.index("limit")
+
+
+def test_complete_query_param_name_required_asterisk_prefix() -> None:
+    """必須クエリパラメータのプレフィックス補完でも * が付く。"""
+    words = ["papycli", "get", "/pet/findByTags", "-q", "t"]
+    result = ctx(words, 4)
+    assert "tags*" in result
+    assert "limit" not in result
+
+
+def test_complete_query_param_excludes_used_with_asterisk() -> None:
+    """補完で tags* を選択後も使用済みとして正しく除外される。"""
+    words = ["papycli", "get", "/pet/findByTags", "-q", "tags*", "foo", "-q", ""]
+    result = ctx(words, 7)
+    assert "tags*" not in result
+    assert "limit" in result
+
+
 # ---------------------------------------------------------------------------
 # クエリパラメータ enum 値の補完 (-q NAME VALUE)
 # ---------------------------------------------------------------------------
@@ -289,6 +324,15 @@ def test_complete_enum_value_no_enum() -> None:
     words = ["papycli", "post", "/pet", "-p", "photoUrls", ""]
     result = ctx(words, 5)
     assert result == []
+
+
+def test_complete_query_enum_value_with_asterisk_param_name() -> None:
+    """-q status* <TAB> でも enum 値が補完される（* を除去して照合）。"""
+    words = ["papycli", "get", "/pet/findByStatus", "-q", "status*", ""]
+    result = ctx(words, 5)
+    assert "available" in result
+    assert "pending" in result
+    assert "sold" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #93

- `-p` / `-q` 補完でパラメータ名候補を表示する際、`required: true` のパラメータを `name*` 形式で返し、任意パラメータより先頭に並べる
- 補完選択後に `name*` がトークンとして挿入されても後続補完（enum 値の補完・使用済み除外）が正しく動作するよう `rstrip("*")` で正規化

**変更前:**
```
$ papycli post /pet -p <TAB>
category   id         name       photoUrls  status     tags
```

**変更後:**
```
$ papycli post /pet -p <TAB>
name*       photoUrls*  category   id         status     tags
```

## Test plan

- [ ] `-p <TAB>` で必須パラメータが `*` 付きで先頭に表示されることを確認
- [ ] `-q <TAB>` でも同様に動作することを確認
- [ ] `name*` を選択後に `-p name* foo -p <TAB>` で `name*` が除外されることを確認
- [ ] `status*` を prev として enum 値補完が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)