### PR TITLE
docs: v0.8.0 以降の変更をドキュメントに反映する（v0.9.0 リリース前）

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -130,7 +130,7 @@ $ papycli get /pet/findByStatus -q status <TAB>
   available  pending  sold
 
 $ papycli post /pet -p <TAB>
-  name  status  photoUrls
+  name*  photoUrls*  status
 
 $ papycli post /pet -p status <TAB>
   available  pending  sold
@@ -256,7 +256,7 @@ papycli <method> <resource> [options]
 
 ```python
 # my_plugin.py
-from papycli.request_filter import RequestContext
+from papycli.filters import RequestContext
 
 def request_filter(ctx: RequestContext) -> RequestContext:
     ctx.headers["X-Request-ID"] = "my-id"

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ papycli get /pet/findByStatus -q status <TAB>
   available  pending  sold
 
 $ papycli post /pet -p <TAB>
-  name  status  photoUrls
+  name*  photoUrls*  status
 
 $ papycli post /pet -p status <TAB>
   available  pending  sold
@@ -257,7 +257,7 @@ A filter is a callable that receives a `RequestContext` and returns a modified `
 
 ```python
 # my_plugin.py
-from papycli.request_filter import RequestContext
+from papycli.filters import RequestContext
 
 def request_filter(ctx: RequestContext) -> RequestContext:
     ctx.headers["X-Request-ID"] = "my-id"

--- a/design_doc.md
+++ b/design_doc.md
@@ -40,7 +40,7 @@ papycli/
 │       ├── checker.py       # --check / --check-strict のパラメータ検証
 │       ├── summary.py       # summary コマンドの出力
 │       ├── completion.py    # bash / zsh 補完スクリプト生成
-│       ├── request_filter.py # リクエストフィルタープラグイン機構
+│       ├── filters.py        # リクエスト・レスポンスフィルタープラグイン機構
 │       └── i18n.py          # 日英ヘルプテキストの切り替えユーティリティ
 ├── tests/
 │   ├── test_api_call.py
@@ -50,7 +50,7 @@ papycli/
 │   ├── test_i18n.py
 │   ├── test_init_cmd.py
 │   ├── test_main.py
-│   ├── test_request_filter.py
+│   ├── test_filters.py
 │   ├── test_spec_loader.py
 │   └── test_summary.py
 ├── examples/
@@ -241,13 +241,13 @@ papycli/
 **目的**: サードパーティプラグインがリクエスト送信前に URL・クエリ・ボディ・ヘッダーを変換できる拡張ポイントを提供する。
 
 **実装内容**:
-- `request_filter.py`
+- `filters.py`
   - `RequestContext` データクラス（`method`, `url`, `query_params`, `body`, `headers`）
   - `load_filters()`: `papycli.request_filters` エントリポイントグループからフィルターをロードし、callable 検証後にプラグイン名の昇順で返す
   - `apply_filters()`: フィルターを順番に適用。各フィルター呼び出し前にスナップショットを作成し（body は deepcopy、他はシャローコピー）、例外・戻り値不正の場合は警告して前の ctx を維持する
 - `api_call.py` の `call_api()` でフィルターを適用するよう更新
   - フィルター適用後の `method` は使用しない（API 定義マッチング時に確定した元の値を使う）
-- テスト: `test_request_filter.py`
+- テスト: `test_filters.py`
   - フィルターの読み込み・適用・例外処理・戻り値型検証など
 
 **プラグイン登録例** (`pyproject.toml`):
@@ -300,7 +300,7 @@ my-filter = "my_plugin:request_filter"
 - `main.py` に `papycli spec --full [resource]` サブコマンドを追加
   - 内部変換後の API 定義ではなく、元の OpenAPI spec を JSON で出力する
   - `resource` 指定時は該当パスのみ絞り込んで表示する
-- `request_filter.py` にレスポンスフィルター機構を追加
+- `filters.py` にレスポンスフィルター機構を追加
   - `ResponseContext` データクラス（`status_code`, `reason`, `body`, `headers`）
   - `load_response_filters()`: `papycli.response_filters` エントリポイントグループからフィルターをロード
   - `apply_response_filters()`: フィルターを順番に適用。例外・戻り値不正の場合は警告して前の ctx を維持する


### PR DESCRIPTION
## Summary

Closes #98

v0.8.0 以降の変更のうち、ドキュメントに未反映だった箇所を修正する。

### README.md / README.ja.md

- **リクエストフィルターのインポートパス修正**（#86 のモジュールリネームに追従）
  ```python
  # 修正前
  from papycli.request_filter import RequestContext
  # 修正後
  from papycli.filters import RequestContext
  ```

- **タブ補完例を更新**（#93 の必須パラメータ `*` 付き先頭表示に追従）
  ```
  # 修正前
  $ papycli post /pet -p <TAB>
    name  status  photoUrls
  # 修正後
  $ papycli post /pet -p <TAB>
    name*  photoUrls*  status
  ```

### design_doc.md

- `request_filter.py` → `filters.py`、`test_request_filter.py` → `test_filters.py` に更新（#86）

## Test plan

- [ ] README.md / README.ja.md のリクエストフィルター例のインポートパスが `papycli.filters` になっていることを確認
- [ ] タブ補完例に `name*`・`photoUrls*` が表示されていることを確認
- [ ] design_doc.md のファイル名が `filters.py` / `test_filters.py` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)