### PR TITLE
fix: release-please PR作成に必要なリポジトリ設定をコメントに追記

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+# このワークフローを動作させるには、リポジトリの以下の設定を有効にする必要がある:
+#   Settings → Actions → General → Workflow permissions
+#   ☑ Allow GitHub Actions to create and approve pull requests
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
Closes #102

## 原因

release-please-action は `GITHUB_TOKEN` を使って PR を作成するが、GitHub リポジトリのデフォルト設定では GitHub Actions による PR 作成が禁止されている。ワークフローに `permissions: pull-requests: write` を記述しても、リポジトリ側の設定が有効でないと PR 作成が拒否される。

## 対応内容

**コードの変更はなし。** ワークフローファイル (`release-please.yml`) に以下の前提条件をコメントとして追記した:

```
Settings → Actions → General → Workflow permissions
☑ Allow GitHub Actions to create and approve pull requests
```

## マージ後の作業

このPRをマージする前、またはマージ後に、リポジトリオーナーが上記のリポジトリ設定を有効にする必要がある。

## テスト計画

- [x] リポジトリ設定「Allow GitHub Actions to create and approve pull requests」を有効にする
- [ ] main への push 後に release-please ワークフローが正常にリリース PR を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)