### PR TITLE
chore: release-please-action を v4.4.0 に固定

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,9 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      # v4.4.0 時点でまだ node20 を使用しており Node.js 24 非対応の warning が出る。
+      # アップストリームが Node.js 24 対応版をリリースした際にバージョンを更新すること。
+      - uses: googleapis/release-please-action@v4.4.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

`googleapis/release-please-action@v4` を `@v4.4.0`（現時点の最新）に固定する。

## 背景

実行ログに以下の warning が出ている：

```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20
and may not work as expected: googleapis/release-please-action@v4.
```

これはアップストリーム側の問題で、v4.4.0 時点でもまだ `node20` を使用しており完全な解消はできない。2026年6月2日以降に Node.js 24 がデフォルトになる予定のため、それまでに upstream が対応版をリリースし次第バージョンを更新する。

`@v4` フローティングタグから `@v4.4.0` に固定することで、意図しない自動更新を防ぎ再現性を確保する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)