### PR TITLE
ci: PRへのコミット追加時に Copilot レビューを自動リクエスト

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -31,10 +31,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # copilot-pull-request-reviewer がコラボレーターでない場合はリクエスト不可。
-          is_collaborator=$(gh api \
-            repos/${{ github.repository }}/collaborators/copilot-pull-request-reviewer \
-            --silent --http-status)
-          if [ "$is_collaborator" != "204" ]; then
+          # gh api は 2xx で exit 0、4xx で exit non-zero を返すため終了コードで判定する。
+          if ! gh api \
+              repos/${{ github.repository }}/collaborators/copilot-pull-request-reviewer \
+              --silent 2>/dev/null; then
             echo "copilot-pull-request-reviewer is not a collaborator; skipping review request."
             exit 0
           fi


### PR DESCRIPTION
## 概要

closes #116

PR ブランチに新しいコミットがプッシュされたとき（`synchronize` イベント）に
GitHub Copilot のコードレビューを自動でリクエストするワークフローを追加します。

## 変更内容

### `.github/workflows/copilot-review.yml`（新規）

- トリガー: `pull_request` の `synchronize` イベントのみ
  - `opened` は除外（PR 作成時はリポジトリ設定の自動レビューが動くため二重実行を防ぐ）
- `gh api` で `copilot-pull-request-reviewer` へレビューリクエストを送信
- 必要な権限: `pull-requests: write`

## 動作確認

このPR自体にコミットを追加プッシュすることで動作を確認できます。

## 注意事項

以下の設定が必要です:
- Settings → Actions → General → Workflow permissions
- ☑ Allow GitHub Actions to create and approve pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)