### PR TITLE
fix: papycli spec のヘルプテキストをユーザー向けに改善

### DIFF
--- a/src/papycli/main.py
+++ b/src/papycli/main.py
@@ -514,22 +514,22 @@ def cmd_summary(resource: str | None, as_csv: bool) -> None:
 @cli.command(
     "spec",
     help=h(
-        "Show request spec (path, method, parameters) for each endpoint.\n\n"
+        "Show request spec (path, method, query/body parameters) for each endpoint.\n\n"
         "Filter by RESOURCE path if given.\n\n"
-        "Use --full to output the full OpenAPI spec including response definitions.\n"
-        "Combine with RESOURCE to filter to a single path.",
-        "各エンドポイントのリクエスト仕様（パス・メソッド・パラメータ）を表示する。\n\n"
+        "Use --full to output the OpenAPI spec (including response definitions).\n"
+        "With RESOURCE, outputs only the matching path entry and referenced schemas.",
+        "各エンドポイントのリクエスト仕様（パス・メソッド・クエリ/ボディパラメータ）を表示する。\n\n"
         "RESOURCE を指定するとそのパスのエントリのみ表示する。\n\n"
-        "--full を指定するとレスポンス定義を含む全 OpenAPI spec を出力する。\n"
-        "RESOURCE と組み合わせると指定パスのみに絞り込む。",
+        "--full を指定するとレスポンス定義を含む OpenAPI spec を出力する。\n"
+        "RESOURCE と組み合わせると該当パスのエントリと参照スキーマのみを出力する。",
     ),
 )
 @click.argument("resource", required=False, default=None)
 @click.option("--full", is_flag=True, default=False, help=h(
-    "Output the full OpenAPI spec including response definitions (JSON)."
-    " Combine with RESOURCE to filter by path.",
-    "レスポンス定義を含む全 OpenAPI spec を JSON 形式で出力する。"
-    "RESOURCE と組み合わせると絞り込み可能。",
+    "Output the OpenAPI spec (JSON). With RESOURCE, outputs only"
+    " the matching path entry and referenced schemas.",
+    "OpenAPI spec を JSON 形式で出力する。RESOURCE を指定すると"
+    "該当パスのエントリと参照スキーマのみを出力する。",
 ))
 def cmd_spec(resource: str | None, full: bool) -> None:
     conf_dir = get_conf_dir()


### PR DESCRIPTION
fixes #124

## Summary

- `--full` なし: 「内部 apidef 形式」→「リクエスト仕様（パス・メソッド・パラメータ）」に変更
- `--full` あり: 「内部に保存された OpenAPI spec」→「レスポンス定義を含む全 OpenAPI spec」に変更
- 既存の E501（行長超過）違反を合わせて修正

## Before / After

**Before:**
```
Show the internal API definition (apidef).
Use --full to output the stored OpenAPI spec instead of the apidef.
```

**After:**
```
Show request spec (path, method, parameters) for each endpoint.
Use --full to output the full OpenAPI spec including response definitions.
```

## Test plan

- [ ] `papycli spec -h` で改善後のヘルプテキストが表示されること
- [ ] `uv run pytest` でユニットテストが全件パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)