### PR TITLE
fix(ci): PRへの追加コミット時にCopilot再レビューが実行されない問題を修正

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -38,14 +38,16 @@ jobs:
             echo "copilot-pull-request-reviewer is not a collaborator; skipping review request."
             exit 0
           fi
-          # すでにレビューリクエスト済みの場合は POST をスキップして冪等にする。
-          # GET で現在の requested_reviewers を確認し、Copilot が含まれていれば何もしない。
+          # すでにレビューリクエスト済みの場合は一度削除してから再リクエストする。
+          # 削除→再追加することで、新しいコミットがプッシュされたときも Copilot が再レビューを行う。
           already_requested=$(gh api \
             repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
             --jq '[.users[].login] | contains(["copilot-pull-request-reviewer"])')
           if [ "$already_requested" = "true" ]; then
-            echo "Copilot is already a requested reviewer; skipping."
-            exit 0
+            echo "Copilot is already a requested reviewer; removing to trigger re-review."
+            gh api --method DELETE \
+              repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+              -f 'reviewers[]=copilot-pull-request-reviewer'
           fi
           gh api --method POST \
             repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \


### PR DESCRIPTION
## Summary

- `copilot-review.yml` で Copilot がすでに reviewers に含まれている場合にレビューリクエストをスキップしていたロジックを変更
- スキップの代わりに、一度 Copilot を reviewers から削除してから再追加することで、新しいコミットがプッシュされるたびに再レビューが実行されるようにした

## Test plan

- [ ] PR に新しいコミットをプッシュしたとき、Copilot Review ワークフローが実行されること
- [ ] Copilot がすでに reviewers に含まれている場合も、削除→再追加が行われて再レビューがリクエストされること
- [ ] fork からの PR はスキップされること（既存動作の維持）

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)