### PR TITLE
fix(test): unittest の PETSTORE_PATH のディレクトリ階層を修正

### DIFF
--- a/tests/unittest/test_init_cmd.py
+++ b/tests/unittest/test_init_cmd.py
@@ -8,7 +8,7 @@ import pytest
 
 from papycli.init_cmd import init_api, register_initialized_api
 
-PETSTORE_PATH = Path(__file__).parent.parent / "examples" / "petstore" / "petstore-oas3.json"
+PETSTORE_PATH = Path(__file__).parent.parent.parent / "examples" / "petstore" / "petstore-oas3.json"
 
 MINIMAL_SPEC: dict[str, Any] = {
     "openapi": "3.0.2",

--- a/tests/unittest/test_main.py
+++ b/tests/unittest/test_main.py
@@ -14,7 +14,7 @@ from papycli.config import load_conf, save_conf
 from papycli.init_cmd import init_api, register_initialized_api
 from papycli.main import cli
 
-PETSTORE_PATH = Path(__file__).parent.parent / "examples" / "petstore" / "petstore-oas3.json"
+PETSTORE_PATH = Path(__file__).parent.parent.parent / "examples" / "petstore" / "petstore-oas3.json"
 BASE_URL = "http://localhost:8080/api/v3"
 
 MINIMAL_SPEC: dict[str, Any] = {

--- a/tests/unittest/test_spec_loader.py
+++ b/tests/unittest/test_spec_loader.py
@@ -57,7 +57,7 @@ MINIMAL_SPEC: dict[str, Any] = {
     },
 }
 
-PETSTORE_PATH = Path(__file__).parent.parent / "examples" / "petstore" / "petstore-oas3.json"
+PETSTORE_PATH = Path(__file__).parent.parent.parent / "examples" / "petstore" / "petstore-oas3.json"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- #123 でテストを `tests/unittest/` に移動した際、3ファイルで `PETSTORE_PATH` の `.parent` 呼び出しが1つ不足していた
- `Path(__file__).parent.parent` → `Path(__file__).parent.parent.parent` に修正

fixes #129

## Test plan

- [ ] `uv run pytest` でユニットテストが全件パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)