### PR TITLE
ci: Copilot Reviewの指摘品質を調整し軽微な指摘を抑制

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,8 +14,8 @@
    - Clear structure, separation of concerns, naming (only when it impacts understanding)
    - Reasonable complexity and duplication (only when meaningful)
 3. **Style / comments / docstrings (light)**:
-   - Basically no need to comment on style unless it is clear mistakes or it impacts readability. 
-   - Otherwise skip
+   - Basically no need to comment on style unless it contains clear mistakes or impacts readability.
+   - Otherwise, skip.
 4. **Verbosity**:
    - Keep the number of comments in a single review up to three.
    - Sort comments by priority and impact, and only include the most important ones.


### PR DESCRIPTION
## 概要
Copilot Review が軽微な瑕疵を過剰に指摘しないよう、レビュー指示を調整しました。

## 変更内容
- 対象: .github/copilot-instructions.md
- Review priorities を見直し、正確性・CLI UX・セキュリティを優先
- Style 指摘を軽量化し、明確な誤りや可読性影響時のみ指摘
- Verbosity ルールを追加し、1レビューあたり最大3件に制限

## 期待効果
- 低インパクト指摘の抑制
- 重大/重要事項の視認性向上
- レビュー対応優先度の判断を容易化

Closes #147