### PR TITLE
docs: ドット記法の1レベル制限に関する記述を削除する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -343,7 +343,6 @@ my-filter = "my_plugin:response_filter"
 
 - リクエストボディは `application/json` のみ対応
 - 配列パラメータはスカラー型（string、integer 等）のみ対応（オブジェクトの配列は非対応）
-- ドット記法によるオブジェクトのネストは 1 レベルのみ対応
 - 認証ヘッダーは `-H "Authorization: Bearer token"` または `PAPYCLI_CUSTOM_HEADER` 環境変数で渡す
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,5 +25,4 @@
 
 - Request bodies are `application/json` only
 - Array parameters support scalar element types only (arrays of objects are not supported)
-- Dot notation for nested objects supports one level of nesting only
 - Pass auth headers via `-H "Authorization: Bearer token"` or the `PAPYCLI_CUSTOM_HEADER` env var

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -25,5 +25,4 @@
 
 - リクエストボディは `application/json` のみ対応
 - 配列パラメータはスカラー型（string、integer 等）のみ対応（オブジェクトの配列は非対応）
-- ドット記法によるオブジェクトのネストは 1 レベルのみ対応
 - 認証ヘッダーは `-H "Authorization: Bearer token"` または `PAPYCLI_CUSTOM_HEADER` 環境変数で渡す

--- a/docs/ja/reference.md
+++ b/docs/ja/reference.md
@@ -39,7 +39,7 @@ papycli <method> <resource> [options]
 |-----------|------|
 | `-H <header: value>` | カスタム HTTP ヘッダー（繰り返し可） |
 | `-q <name> <value>` | クエリパラメータ（繰り返し可）。リソースパスにクエリ文字列を直接埋め込むことも可能: `/pet/findByStatus?status=available`。インラインパラメータは `-q` より先に送信される。 |
-| `-p <name> <value>` | ボディパラメータ（繰り返し可）。API 仕様に基づいて値を適切な JSON 型（integer / number / boolean）に自動変換する。文字列はそのまま送信される。同じキーを繰り返すと JSON 配列を構築する。ドット記法でネストしたオブジェクトを構築できる（1 レベルのみ）。 |
+| `-p <name> <value>` | ボディパラメータ（繰り返し可）。API 仕様に基づいて値を適切な JSON 型（integer / number / boolean）に自動変換する。文字列はそのまま送信される。同じキーを繰り返すと JSON 配列を構築する。ドット記法でネストしたオブジェクトを構築できる。 |
 | `-d <json>` | 生の JSON ボディ（`-p` を上書きする） |
 | `--summary` | リクエストを送らずにエンドポイント情報を表示する |
 | `--check` | 送信前にパラメータを検証する（警告を stderr に出力、リクエストは送信） |
@@ -56,7 +56,7 @@ papycli <method> <resource> [options]
 papycli put /pet -p photoUrls "http://example.com/a.jpg" -p photoUrls "http://example.com/b.jpg"
 # → {"photoUrls": ["http://example.com/a.jpg", "http://example.com/b.jpg"]}
 
-# ドット記法でネストしたオブジェクトを構築する（1 レベル）
+# ドット記法でネストしたオブジェクトを構築する
 papycli put /pet -p category.id 2 -p category.name "Dogs"
 # → {"category": {"id": 2, "name": "Dogs"}}
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,7 +39,7 @@ papycli <method> <resource> [options]
 |--------|-------------|
 | `-H <header: value>` | Custom HTTP header (repeatable) |
 | `-q <name> <value>` | Query parameter (repeatable). You can also embed query parameters directly in the resource path: `/pet/findByStatus?status=available`. Inline parameters are sent before any `-q` parameters. |
-| `-p <name> <value>` | Body parameter (repeatable). Values are coerced to the correct JSON type (integer, number, boolean) based on the API spec. Strings are passed as-is. Repeat the same key to build a JSON array. Use dot notation to build a nested object (one level deep). |
+| `-p <name> <value>` | Body parameter (repeatable). Values are coerced to the correct JSON type (integer, number, boolean) based on the API spec. Strings are passed as-is. Repeat the same key to build a JSON array. Use dot notation to build a nested object. |
 | `-d <json>` | Raw JSON body (overrides `-p`) |
 | `--summary` | Show endpoint info without sending a request |
 | `--check` | Validate params before sending (warn on stderr, request is still sent) |
@@ -56,7 +56,7 @@ papycli <method> <resource> [options]
 papycli put /pet -p photoUrls "http://example.com/a.jpg" -p photoUrls "http://example.com/b.jpg"
 # → {"photoUrls": ["http://example.com/a.jpg", "http://example.com/b.jpg"]}
 
-# Use dot notation to build a nested object (one level)
+# Use dot notation to build a nested object
 papycli put /pet -p category.id 2 -p category.name "Dogs"
 # → {"category": {"id": 2, "name": "Dogs"}}
 


### PR DESCRIPTION
## Summary

- PR #145 で任意の深さのネストオブジェクトがサポートされたため、「1 レベルのみ」という制限事項の記述をドキュメントから削除する
- 対象ファイル: `README.ja.md`, `docs/index.md`, `docs/ja/index.md`, `docs/ja/reference.md`, `docs/reference.md`

closes #149

## Test plan

- [ ] 変更後のドキュメントに「1 レベル」という記述が残っていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)