### PR TITLE
fix: 静的補完スクリプトで利用不可能なオプションが候補に表示されるバグを修正

### DIFF
--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -30,7 +30,7 @@ _ALL_OPTS = [
     "--check-strict",
     "--response-check",
 ]
-_BASE_OPTS = ["-H", "--summary", "-v", "--verbose", "--check", "--check-strict", "--response-check"]
+_BASE_OPTS = [opt for opt in _ALL_OPTS if opt not in ("-q", "-p", "-d")]
 
 # ---------------------------------------------------------------------------
 # シェルスクリプトテンプレート

--- a/tests/unittest/test_completion.py
+++ b/tests/unittest/test_completion.py
@@ -910,8 +910,16 @@ class TestGenerateStaticScript:
     def test_zsh_static_option_cases_exist(self) -> None:
         # zsh 静的スクリプトにオプション候補フィルタリング用の case 文が含まれること
         script = generate_static_script("zsh", "papycli", APIDEF, ["petstore"])
-        # GET /pet/findByStatus はクエリパラメータあり → -q を含む case アームが存在する
-        assert "-q" in script
+        # GET /pet/findByStatus はクエリパラメータあり → options case アームに '-q' が含まれること
+        # options case アームは --summary を含む行で識別する（パラメータ case アームとの区別）
+        lines = script.splitlines()
+        target = "get:/pet/findByStatus"
+        for line in lines:
+            if target in line and "--summary" in line:
+                assert "'-q'" in line, f"'-q' not found in options case arm for {target!r}: {line}"
+                break
+        else:
+            raise AssertionError(f"Options case arm for {target!r} not found in zsh script")
         # GET /pet/{petId} 対応の case アーム内で -q が除かれていること（フォールバック行以外）
         # zsh ワイルドカードパターン 'get:/pet/'[^/ ][^/ ]* が存在する
         assert "'get:/pet/'[^/ ][^/ ]*" in script


### PR DESCRIPTION
## Summary

- `papycli get /pet/1 ` + TAB で `-q`/`-p`/`-d` など使えないオプションが表示されるバグを修正 (Closes #158)
- `config completion-script` で生成する静的補完スクリプトに、エンドポイント別のオプションフィルタリング case 文を追加（bash/zsh 両対応）
- 動的補完（`_complete` サブコマンド経由）は既に正しくフィルタリングしており、静的スクリプトもそれに合わせた

## Root Cause

`generate_static_script` が生成するスクリプトのオプション補完部分がすべてのオプションをハードコードしており、エンドポイントの `query_parameters` / `post_parameters` の有無を考慮していなかった。

## Test plan

- [ ] `test_bash_static_hides_q_p_d_for_no_params`: クエリ・ボディパラメータなしのエンドポイントで `-q`/`-p`/`-d` が非表示になること（bash）
- [ ] `test_bash_static_shows_q_for_query_params`: クエリパラメータありのエンドポイントで `-q` が表示されること（bash）
- [ ] `test_bash_static_shows_p_d_for_body_params`: ボディパラメータありのエンドポイントで `-p`/`-d` が表示されること（bash）
- [ ] `test_bash_static_fallback_shows_all_for_unknown_path`: 未知パスではすべてのオプションが表示されること（bash フォールバック）
- [ ] `test_zsh_static_option_cases_exist` / `test_zsh_static_no_param_endpoint_omits_q`: zsh スクリプトに同等の case 文が含まれること
- [ ] 既存テスト 517 件がすべてパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)