### PR TITLE
fix: api_call.py の mypy エラーを修正 (ResponseContext | None の型不整合)

### DIFF
--- a/src/papycli/api_call.py
+++ b/src/papycli/api_call.py
@@ -451,10 +451,11 @@ def call_api(
             request_body=ctx.body,
             schema=resp_schema,
         )
-        resp_ctx = apply_response_filters(resp_ctx, response_filters)
-        if resp_ctx is None:
+        filtered_ctx = apply_response_filters(resp_ctx, response_filters)
+        if filtered_ctx is None:
             # フィルターが None を返してチェーンを中断した。出力を抑制するため None を返す。
             return None
+        resp_ctx = filtered_ctx
 
         # フィルターがフィールドを変更した場合、resp に反映する。
         # ボディ: 値の等価比較で変更を検出し、_content・encoding・Content-Type を更新する。


### PR DESCRIPTION
## Summary

- `apply_response_filters` の戻り値型 `ResponseContext | None` を `ResponseContext` 型の変数に直接代入していた型エラーを修正
- フィルター結果を `filtered_ctx` で受け取り、None チェック後に `resp_ctx` へ代入する形に変更

Closes #175

## Test plan

- [x] `uv run ruff check src` — パス
- [x] `uv run mypy src` — パス (エラー 0)
- [x] `uv run pytest` — 538 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)