### PR TITLE
feat(examples): Redmine REST API の使用例を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ __marimo__/
 
 # Git worktrees
 .worktrees/
+
+# Example OpenAPI specs (downloaded separately, not committed)
+examples/redmine/openapi.yaml

--- a/examples/redmine/Dockerfile
+++ b/examples/redmine/Dockerfile
@@ -1,0 +1,12 @@
+FROM redmine:6.0
+
+COPY docker-init.sh /docker-init.sh
+RUN chmod +x /docker-init.sh \
+    # Inject init script just before the final `exec "$@"` in the original entrypoint.
+    # The entrypoint re-runs itself via `gosu redmine` when called as root, so the
+    # injected code runs as the redmine user after DB setup and migrations are complete.
+    && head -n -1 /docker-entrypoint.sh > /tmp/entrypoint_new.sh \
+    && echo 'if [ -n "$isLikelyRedmine" ]; then /docker-init.sh; fi' >> /tmp/entrypoint_new.sh \
+    && echo 'exec "$@"' >> /tmp/entrypoint_new.sh \
+    && mv /tmp/entrypoint_new.sh /docker-entrypoint.sh \
+    && chmod +x /docker-entrypoint.sh

--- a/examples/redmine/Dockerfile
+++ b/examples/redmine/Dockerfile
@@ -2,11 +2,14 @@ FROM redmine:6.0
 
 COPY docker-init.sh /docker-init.sh
 RUN chmod +x /docker-init.sh \
-    # Inject init script just before the final `exec "$@"` in the original entrypoint.
+    # Inject init script just before `exec "$@"` in the original entrypoint.
+    # Verify the expected line exists first — if not, fail the build explicitly so
+    # upstream entrypoint changes do not silently produce a broken image.
     # The entrypoint re-runs itself via `gosu redmine` when called as root, so the
     # injected code runs as the redmine user after DB setup and migrations are complete.
-    && head -n -1 /docker-entrypoint.sh > /tmp/entrypoint_new.sh \
-    && echo 'if [ -n "$isLikelyRedmine" ]; then /docker-init.sh; fi' >> /tmp/entrypoint_new.sh \
-    && echo 'exec "$@"' >> /tmp/entrypoint_new.sh \
+    && grep -qx 'exec "$@"' /docker-entrypoint.sh \
+        || { echo 'ERROR: expected line `exec "$@"` not found in /docker-entrypoint.sh' >&2; exit 1; } \
+    && sed '/^exec "\$@"$/i if [ -n "$isLikelyRedmine" ]; then /docker-init.sh; fi' \
+        /docker-entrypoint.sh > /tmp/entrypoint_new.sh \
     && mv /tmp/entrypoint_new.sh /docker-entrypoint.sh \
     && chmod +x /docker-entrypoint.sh

--- a/examples/redmine/README.md
+++ b/examples/redmine/README.md
@@ -6,20 +6,25 @@ OpenAPI spec は [d-yoshi/redmine-openapi](https://github.com/d-yoshi/redmine-op
 
 ## 事前準備
 
+以下の手順はすべて `examples/redmine` ディレクトリで実行してください。
+
+```bash
+cd examples/redmine
+```
+
 ### 1. OpenAPI spec を取得する
 
 このディレクトリには OpenAPI spec ファイルは含まれていません。
 以下のコマンドで [d-yoshi/redmine-openapi](https://github.com/d-yoshi/redmine-openapi) から取得してください。
 
 ```bash
-curl -o examples/redmine/openapi.yaml \
+curl -o openapi.yaml \
   https://raw.githubusercontent.com/d-yoshi/redmine-openapi/main/openapi.yaml
 ```
 
 ### 2. Redmine を起動する
 
 ```bash
-cd examples/redmine
 docker compose up -d
 ```
 
@@ -47,7 +52,7 @@ docker compose exec redmine bash -c \
 ### 4. papycli に登録する
 
 ```bash
-papycli config add examples/redmine/openapi.yaml
+papycli config add openapi.yaml
 ```
 
 設定ファイル (`~/.papycli/papycli.conf`) を開き、登録された `openapi` エントリの `url` と名前を編集します。

--- a/examples/redmine/README.md
+++ b/examples/redmine/README.md
@@ -1,0 +1,150 @@
+# Redmine example
+
+[papycli](https://github.com/tmonj1/papycli) から [Redmine](https://www.redmine.org/) の REST API を呼び出すサンプルです。
+
+OpenAPI spec は [d-yoshi/redmine-openapi](https://github.com/d-yoshi/redmine-openapi) の非公式仕様 (OpenAPI 3.0.3) を使用しています。
+
+## 事前準備
+
+### 1. OpenAPI spec を取得する
+
+このディレクトリには OpenAPI spec ファイルは含まれていません。
+以下のコマンドで [d-yoshi/redmine-openapi](https://github.com/d-yoshi/redmine-openapi) から取得してください。
+
+```bash
+curl -o examples/redmine/openapi.yaml \
+  https://raw.githubusercontent.com/d-yoshi/redmine-openapi/main/openapi.yaml
+```
+
+### 2. Redmine を起動する
+
+```bash
+cd examples/redmine
+docker compose up -d
+```
+
+起動時に以下を自動で実行します。
+
+- REST API の有効化
+- トラッカー・ステータス・優先度などのデフォルトデータの投入（初回のみ）
+
+起動完了まで数十秒〜数分かかります。以下のコマンドで `200` が返れば準備完了です。
+
+```bash
+curl -o /dev/null -w "%{http_code}\n" http://localhost:3000/projects.json
+```
+
+### 3. API キーを取得する
+
+```bash
+docker compose exec redmine bash -c \
+  "cd /usr/src/redmine && bundle exec rails runner \
+  'Rails.logger = Logger.new(IO::NULL); puts User.find_by(login: \"admin\").api_key'"
+```
+
+表示された API キーを以下の手順で使用します。
+
+### 4. papycli に登録する
+
+```bash
+papycli config add examples/redmine/openapi.yaml
+```
+
+設定ファイル (`~/.papycli/papycli.conf`) を開き、登録された `openapi` エントリの `url` と名前を編集します。
+
+```json
+"redmine": {
+  "openapispec": "openapi.yaml",
+  "apidef": "openapi.json",
+  "url": "http://localhost:3000"
+}
+```
+
+アクティブな API を redmine に切り替えます。
+
+```bash
+papycli config use redmine
+```
+
+## 使い方
+
+API キーを環境変数に設定しておくと便利です。
+
+```bash
+export REDMINE_API_KEY=<your-api-key>
+```
+
+### プロジェクト一覧を取得する
+
+```bash
+papycli get /projects.json -H "X-Redmine-API-Key: $REDMINE_API_KEY"
+```
+
+### プロジェクトを作成する
+
+```bash
+papycli post /projects.json \
+  -H "X-Redmine-API-Key: $REDMINE_API_KEY" \
+  -d '{"project": {"name": "My Project", "identifier": "my-project"}}'
+```
+
+> **注意:** issue を作成する前に、プロジェクトにトラッカーを関連付ける必要があります。
+>
+> ```bash
+> papycli put /projects/1.json \
+>   -H "X-Redmine-API-Key: $REDMINE_API_KEY" \
+>   -d '{"project": {"tracker_ids": [1, 2, 3]}}'
+> ```
+
+### issue を作成する
+
+```bash
+papycli post /issues.json \
+  -H "X-Redmine-API-Key: $REDMINE_API_KEY" \
+  -d '{"issue": {"project_id": 1, "tracker_id": 1, "priority_id": 2, "subject": "My issue"}}'
+```
+
+パラメータの目安:
+
+| フィールド | 値 | 意味 |
+|-----------|---|------|
+| `tracker_id` | 1 / 2 / 3 | Bug / Feature / Support |
+| `priority_id` | 1〜5 | Low / Normal / High / Urgent / Immediate |
+
+### issue 一覧を取得する
+
+```bash
+papycli get /issues.json -H "X-Redmine-API-Key: $REDMINE_API_KEY"
+```
+
+### issue を更新する
+
+```bash
+papycli put /issues/1.json \
+  -H "X-Redmine-API-Key: $REDMINE_API_KEY" \
+  -d '{"issue": {"done_ratio": 50, "notes": "進捗を更新"}}'
+```
+
+### ログインユーザー情報を取得する
+
+```bash
+papycli get /users/current.json -H "X-Redmine-API-Key: $REDMINE_API_KEY"
+```
+
+### エンドポイント一覧を確認する
+
+```bash
+papycli summary
+```
+
+## コンテナを停止する
+
+```bash
+docker compose down
+```
+
+データを削除する場合は `-v` オプションを付けてください。
+
+```bash
+docker compose down -v
+```

--- a/examples/redmine/docker-compose.yml
+++ b/examples/redmine/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  redmine:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      REDMINE_DB_MYSQL: db
+      REDMINE_DB_DATABASE: redmine
+      REDMINE_DB_USERNAME: redmine
+      REDMINE_DB_PASSWORD: redmine
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: redmine
+      MYSQL_USER: redmine
+      MYSQL_PASSWORD: redmine
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "redmine", "-predmine"]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/examples/redmine/docker-compose.yml
+++ b/examples/redmine/docker-compose.yml
@@ -19,8 +19,13 @@ services:
       MYSQL_DATABASE: redmine
       MYSQL_USER: redmine
       MYSQL_PASSWORD: redmine
+    volumes:
+      - redmine-mysql-data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "redmine", "-predmine"]
       interval: 10s
       timeout: 5s
       retries: 10
+
+volumes:
+  redmine-mysql-data:

--- a/examples/redmine/docker-init.sh
+++ b/examples/redmine/docker-init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Suppress Rails logger output so that only explicit `print` output goes to stdout
+SILENCE='Rails.logger = Logger.new(IO::NULL);'
+
+# Enable REST API (idempotent)
+echo "Enabling REST API..."
+bundle exec rails runner "${SILENCE} Setting.rest_api_enabled = '1'"
+
+# Load default data only if trackers have not been set up yet
+echo "Checking default data..."
+tracker_count=$(bundle exec rails runner "${SILENCE} print Tracker.count" | tail -1)
+if [ "$tracker_count" = "0" ]; then
+  echo "Loading default data..."
+  REDMINE_LANG=en bundle exec rake redmine:load_default_data
+else
+  echo "Default data already loaded, skipping."
+fi

--- a/examples/redmine/docker-init.sh
+++ b/examples/redmine/docker-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
-# Suppress Rails logger output so that only explicit `print` output goes to stdout
+# Suppress Rails logger output so that only explicit output goes to stdout
 SILENCE='Rails.logger = Logger.new(IO::NULL);'
 
 # Enable REST API (idempotent)
@@ -10,7 +10,7 @@ bundle exec rails runner "${SILENCE} Setting.rest_api_enabled = '1'"
 
 # Load default data only if trackers have not been set up yet
 echo "Checking default data..."
-tracker_count=$(bundle exec rails runner "${SILENCE} print Tracker.count" | tail -1)
+tracker_count=$(bundle exec rails runner "${SILENCE} puts Tracker.count" | grep -E '^[0-9]+$')
 if [ "$tracker_count" = "0" ]; then
   echo "Loading default data..."
   REDMINE_LANG=en bundle exec rake redmine:load_default_data


### PR DESCRIPTION
## Summary

- `examples/redmine/docker-compose.yml`: Redmine + MySQL をコンテナで起動する構成を追加
- `examples/redmine/Dockerfile`: 起動時に REST API 有効化とデフォルトデータ投入を自動実行するカスタムイメージ
- `examples/redmine/docker-init.sh`: 初期化スクリプト（REST API 有効化・デフォルトデータ投入）
- `examples/redmine/README.md`: OpenAPI spec の入手先・起動手順・papycli での使い方

OpenAPI spec (`openapi.yaml`) は [d-yoshi/redmine-openapi](https://github.com/d-yoshi/redmine-openapi) から別途取得する設計のため、`.gitignore` に追加しコミットには含めていません。

Closes #183

## Test plan

- [ ] `docker compose up -d` で Redmine が起動すること
- [ ] 起動ログに "Enabling REST API..." "Loading default data..." が出力されること
- [ ] `GET /trackers.json` でトラッカー一覧が取得できること
- [ ] `POST /issues.json` で issue が作成できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)