### PR TITLE
feat(summary): summaryサブコマンドの出力をリソース・メソッド別の構造化テキストに変更する

### DIFF
--- a/src/papycli/spec_loader.py
+++ b/src/papycli/spec_loader.py
@@ -71,7 +71,9 @@ def _extract_schema_properties(
     return required, properties
 
 
-def _param_entry(name: str, schema: dict[str, Any], required: bool) -> dict[str, Any]:
+def _param_entry(
+    name: str, schema: dict[str, Any], required: bool, description: str = ""
+) -> dict[str, Any]:
     entry: dict[str, Any] = {
         "name": name,
         "type": schema.get("type", "string"),
@@ -79,6 +81,8 @@ def _param_entry(name: str, schema: dict[str, Any], required: bool) -> dict[str,
     }
     if "enum" in schema:
         entry["enum"] = schema["enum"]
+    if description:
+        entry["description"] = description
     return entry
 
 
@@ -105,7 +109,12 @@ def spec_to_apidef(spec: dict[str, Any]) -> dict[str, Any]:
                 merged_params[p["name"]] = p
 
             query_parameters = [
-                _param_entry(p["name"], p.get("schema", {}), bool(p.get("required", False)))
+                _param_entry(
+                    p["name"],
+                    p.get("schema", {}),
+                    bool(p.get("required", False)),
+                    p.get("description", ""),
+                )
                 for p in merged_params.values()
                 if p.get("in") == "query"
             ]
@@ -121,13 +130,17 @@ def spec_to_apidef(spec: dict[str, Any]) -> dict[str, Any]:
             if json_schema:
                 req_fields, props = _extract_schema_properties(json_schema)
                 post_parameters = [
-                    _param_entry(name, prop_schema, name in req_fields)
+                    _param_entry(
+                        name, prop_schema, name in req_fields, prop_schema.get("description", "")
+                    )
                     for name, prop_schema in props.items()
                 ]
 
+            op_description = operation.get("summary") or operation.get("description") or ""
             methods.append(
                 {
                     "method": method,
+                    "description": op_description,
                     "query_parameters": query_parameters,
                     "post_parameters": post_parameters,
                 }

--- a/src/papycli/summary.py
+++ b/src/papycli/summary.py
@@ -5,7 +5,6 @@ import io
 from typing import Any, TextIO
 
 from rich.console import Console
-from rich.table import Table
 
 
 def _format_param(p: dict[str, Any], flag: str) -> str:
@@ -49,27 +48,54 @@ def print_summary(
     *,
     file: TextIO | None = None,
 ) -> None:
-    """エンドポイント一覧を rich テーブルで出力する。"""
-    rows = build_rows(apidef, resource_filter)
-    if not rows:
-        click_echo = print if file is None else lambda s: file.write(s + "\n")
-        click_echo("(no endpoints found)")
-        return
+    """エンドポイント一覧をリソース・メソッド別の構造化テキストで出力する。"""
+    console = Console(file=file, highlight=False, no_color=(file is not None))
+    found = False
 
-    table = Table(
-        show_header=True,
-        header_style="bold",
-        box=None,
-        pad_edge=False,
-        show_edge=False,
-    )
-    table.add_column("METHOD", min_width=8)
-    table.add_column("PATH", min_width=24)
-    table.add_column("PARAMETERS")
-    for method, path, params in rows:
-        table.add_row(method, path, params)
+    for path in sorted(apidef.keys()):
+        if resource_filter and not path.startswith(resource_filter):
+            continue
+        ops = apidef[path]
+        if not ops:
+            continue
+        found = True
 
-    Console(file=file, highlight=False, no_color=(file is not None)).print(table)
+        console.print("RESOURCE")
+        console.print(f"  {path}")
+        console.print()
+        console.print("METHODS:")
+
+        for op in ops:
+            method = op["method"].upper()
+            console.print(f"  {method}")
+            console.print()
+
+            desc = op.get("description", "")
+            if desc:
+                console.print("  DESCRIPTION:")
+                console.print(f"    {desc}")
+                console.print()
+
+            q_params = op.get("query_parameters", [])
+            if q_params:
+                console.print("  QUERY PARAMETERS")
+                for p in q_params:
+                    p_desc = p.get("description", "")
+                    line = f"    {p['name']}: {p_desc}" if p_desc else f"    {p['name']}"
+                    console.print(line)
+                console.print()
+
+            p_params = op.get("post_parameters", [])
+            if p_params:
+                console.print("  PROPERTIES")
+                for p in p_params:
+                    p_desc = p.get("description", "")
+                    line = f"    {p['name']}: {p_desc}" if p_desc else f"    {p['name']}"
+                    console.print(line)
+                console.print()
+
+    if not found:
+        console.print("(no endpoints found)")
 
 
 def format_summary_csv(apidef: dict[str, Any]) -> str:

--- a/tests/unittest/test_spec_loader.py
+++ b/tests/unittest/test_spec_loader.py
@@ -182,6 +182,108 @@ def test_spec_to_apidef_methods_only_defined() -> None:
     assert methods == {"get", "delete"}
 
 
+def test_spec_to_apidef_operation_description_from_summary() -> None:
+    """summary フィールドが operation の description として抽出される。"""
+    spec: dict[str, Any] = {
+        "paths": {
+            "/things": {
+                "get": {
+                    "summary": "List all things",
+                    "parameters": [],
+                }
+            }
+        }
+    }
+    apidef = spec_to_apidef(spec)
+    get_op = apidef["/things"][0]
+    assert get_op["description"] == "List all things"
+
+
+def test_spec_to_apidef_operation_description_fallback_to_description() -> None:
+    """summary がない場合、description フィールドが使われる。"""
+    spec: dict[str, Any] = {
+        "paths": {
+            "/things": {
+                "get": {
+                    "description": "Detailed description",
+                    "parameters": [],
+                }
+            }
+        }
+    }
+    apidef = spec_to_apidef(spec)
+    get_op = apidef["/things"][0]
+    assert get_op["description"] == "Detailed description"
+
+
+def test_spec_to_apidef_operation_description_empty_when_absent() -> None:
+    """summary も description もない場合、空文字が設定される。"""
+    apidef = spec_to_apidef(MINIMAL_SPEC)
+    get_op = next(op for op in apidef["/items"] if op["method"] == "get")
+    assert get_op["description"] == ""
+
+
+def test_spec_to_apidef_query_param_description() -> None:
+    """クエリパラメータの description が抽出される。"""
+    spec: dict[str, Any] = {
+        "paths": {
+            "/items": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "status",
+                            "in": "query",
+                            "required": False,
+                            "description": "Filter by status",
+                            "schema": {"type": "string"},
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    apidef = spec_to_apidef(spec)
+    get_op = apidef["/items"][0]
+    param = get_op["query_parameters"][0]
+    assert param["description"] == "Filter by status"
+
+
+def test_spec_to_apidef_post_param_description() -> None:
+    """リクエストボディのプロパティ description が抽出される。"""
+    spec: dict[str, Any] = {
+        "paths": {
+            "/items": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string", "description": "Item name"},
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    apidef = spec_to_apidef(spec)
+    post_op = apidef["/items"][0]
+    param = post_op["post_parameters"][0]
+    assert param["description"] == "Item name"
+
+
+def test_spec_to_apidef_param_no_description_key_absent() -> None:
+    """description がない場合、キー自体が存在しない。"""
+    apidef = spec_to_apidef(MINIMAL_SPEC)
+    get_op = next(op for op in apidef["/items"] if op["method"] == "get")
+    param = get_op["query_parameters"][0]
+    assert "description" not in param
+
+
 # ---------------------------------------------------------------------------
 # allOf
 # ---------------------------------------------------------------------------

--- a/tests/unittest/test_summary.py
+++ b/tests/unittest/test_summary.py
@@ -18,9 +18,10 @@ APIDEF: dict[str, Any] = {
     "/pet": [
         {
             "method": "post",
+            "description": "Add a new pet to the store",
             "query_parameters": [],
             "post_parameters": [
-                {"name": "name", "type": "string", "required": True},
+                {"name": "name", "type": "string", "required": True, "description": "Pet name"},
                 {"name": "status", "type": "string", "required": False,
                  "enum": ["available", "pending", "sold"]},
                 {"name": "photoUrls", "type": "array", "required": True},
@@ -30,19 +31,23 @@ APIDEF: dict[str, Any] = {
     "/pet/findByStatus": [
         {
             "method": "get",
+            "description": "Finds Pets by status",
             "query_parameters": [
-                {"name": "status", "type": "string", "required": False,
-                 "enum": ["available", "pending", "sold"]},
+                {
+                    "name": "status", "type": "string", "required": False,
+                    "enum": ["available", "pending", "sold"],
+                    "description": "Status values to filter by",
+                },
             ],
             "post_parameters": [],
         }
     ],
     "/pet/{petId}": [
-        {"method": "get", "query_parameters": [], "post_parameters": []},
-        {"method": "delete", "query_parameters": [], "post_parameters": []},
+        {"method": "get", "description": "", "query_parameters": [], "post_parameters": []},
+        {"method": "delete", "description": "", "query_parameters": [], "post_parameters": []},
     ],
     "/store/inventory": [
-        {"method": "get", "query_parameters": [], "post_parameters": []}
+        {"method": "get", "description": "", "query_parameters": [], "post_parameters": []}
     ],
 }
 
@@ -156,6 +161,52 @@ def test_print_summary_empty_apidef() -> None:
     print_summary({}, file=buf)
     output = buf.getvalue()
     assert "no endpoints" in output
+
+
+def test_print_summary_shows_resource_section() -> None:
+    buf = io.StringIO()
+    print_summary(APIDEF, file=buf)
+    output = buf.getvalue()
+    assert "RESOURCE" in output
+    assert "METHODS:" in output
+
+
+def test_print_summary_shows_description() -> None:
+    buf = io.StringIO()
+    print_summary(APIDEF, file=buf)
+    output = buf.getvalue()
+    assert "DESCRIPTION:" in output
+    assert "Add a new pet to the store" in output
+
+
+def test_print_summary_shows_query_parameters_section() -> None:
+    buf = io.StringIO()
+    print_summary(APIDEF, file=buf)
+    output = buf.getvalue()
+    assert "QUERY PARAMETERS" in output
+    assert "status" in output
+    assert "Status values to filter by" in output
+
+
+def test_print_summary_shows_properties_section() -> None:
+    buf = io.StringIO()
+    print_summary(APIDEF, file=buf)
+    output = buf.getvalue()
+    assert "PROPERTIES" in output
+    assert "name: Pet name" in output
+
+
+def test_print_summary_no_description_section_when_empty() -> None:
+    """description が空のメソッドには DESCRIPTION セクションを表示しない。"""
+    buf = io.StringIO()
+    apidef: dict[str, Any] = {
+        "/items": [
+            {"method": "get", "description": "", "query_parameters": [], "post_parameters": []}
+        ]
+    }
+    print_summary(apidef, file=buf)
+    output = buf.getvalue()
+    assert "DESCRIPTION:" not in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `spec_loader.py`: operation の `summary`/`description` フィールド、クエリパラメータおよびリクエストボディプロパティの `description` フィールドを内部フォーマットに追加
- `summary.py`: `print_summary` をテーブル形式から以下の構造化テキスト出力に変更

```
RESOURCE
  /pet

METHODS:
  POST

  DESCRIPTION:
    Add a new pet to the store

  PROPERTIES
    name: Pet name
    status
    photoUrls
```

Closes #187

## Test plan

- [x] `uv run pytest` でテスト全件パス (552 passed)
- [x] `uv run ruff check` でエラーなし（既存の問題のみ）
- [x] `uv run mypy src` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)