### PR TITLE
docs: README タイトルを改訂する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# papycli — OpenAPI 3.0 REST API を操作する Python 製 CLI
+# papycli — OpenAPI 3.0 仕様から REST API を CLI で呼び出すツール
 
 `papycli` は OpenAPI 3.0 仕様を読み込み、REST API エンドポイントをターミナルから直接呼び出せるインタラクティブな CLI を提供します。
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# papycli — Python CLI for OpenAPI 3.0 REST APIs
+# papycli — Turn Any OpenAPI 3.0 Spec into a CLI
 
 `papycli` is an interactive CLI that reads OpenAPI 3.0 specs and lets you call REST API endpoints directly from the terminal.
 


### PR DESCRIPTION
## Summary

- README.md: `Python CLI for OpenAPI 3.0 REST APIs` → `Turn Any OpenAPI 3.0 Spec into a CLI`
- README.ja.md: `OpenAPI 3.0 REST API を操作する Python 製 CLI` → `OpenAPI 3.0 仕様から REST API を CLI で呼び出すツール`

Python 実装を強調する文言から、「OpenAPI spec があればどんな REST API でも CLI として使える」というツールの価値を伝える文言に変更する。

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)