### PR TITLE
chore: .claude/settings.json の設定を settings.local.json に移動する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,1 @@
-{
-  "env": {
-    "ENABLE_LSP_TOOL": "1"
-  },
-  "enabledPlugins": {
-    "pyright-lsp@claude-plugins-official": true
-  },
-  "permissions": {
-    "deny": [
-      "Read(/**/.env)",
-      "Read(/**/*.pem)",
-      "Read(/**/*.key)",
-      "Read(/**/*.p12)"
-    ]
-  }
-}
+{}

--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ __marimo__/
 
 # Example OpenAPI specs (downloaded separately, not committed)
 examples/redmine/openapi.yaml
+
+# Claude Code local settings (machine-specific, not committed)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- `.claude/settings.json` に含まれていた個人環境依存の設定をリポジトリから除外するため、`.claude/settings.local.json` に移動
- `settings.json` は空（`{}`）にする
- `.gitignore` に `.claude/settings.local.json` を追加してローカル専用ファイルとして管理

Closes #191

## Test plan

- [ ] `.claude/settings.json` が `{}` になっていることを確認
- [ ] `.claude/settings.local.json` に全設定が含まれていることを確認
- [ ] `.claude/settings.local.json` が `.gitignore` 対象になっていることを確認（`git status` で追跡されないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)