### PR TITLE
feat!: --api オプションを追加し config alias コマンドを廃止する

### DIFF
--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -380,6 +380,15 @@ _@@SAFENAME@@_completion() {
     fi
     local _cword=$(( COMP_CWORD - _off ))
 
+    if [[ ${_cword} -eq 1 ]]; then
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W '--api' -- "$cur"))
+        else
+            COMPREPLY=($(compgen -W @@TOP_LEVEL_CMDS@@ -- "$cur"))
+        fi
+        return
+    fi
+
     local cmd="${COMP_WORDS[$((1 + _off))]}"
 
     if [[ "$cmd" == "config" ]]; then
@@ -521,6 +530,16 @@ _@@SAFENAME@@() {
         _off=2
     fi
     local _cword=$(( cword - _off ))
+
+    if [[ $_cword -eq 1 ]]; then
+        if [[ "$cur" == -* ]]; then
+            _c=('--api'); _describe 'option' _c
+        else
+            _c=(@@TOP_LEVEL_CMDS_ZSH@@)
+            _describe 'command' _c
+        fi
+        return
+    fi
 
     local cmd="${words[$((2 + _off))]}"
 

--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -15,7 +15,7 @@ _SAFE_CMD_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 _PLACEHOLDER_RE = re.compile(r"\{[^}]+\}")
 
 METHODS = ["get", "post", "put", "patch", "delete"]
-CONFIG_SUBCOMMANDS = ["add", "alias", "completion-script", "list", "log", "remove", "use"]
+CONFIG_SUBCOMMANDS = ["add", "completion-script", "list", "log", "remove", "use"]
 TOP_LEVEL_COMMANDS = METHODS + ["config", "spec", "summary"]
 
 _ALL_OPTS = [
@@ -230,6 +230,18 @@ def completions_for_context(
             and api_names is not None
         ):
             return [n for n in api_names if n.startswith(incomplete)]
+        if current >= 3 and len(words) > 2 and words[2] == "completion-script":
+            # completion-script <shell> [--api <apiname>]
+            if current == 3:
+                return [s for s in ["bash", "zsh"] if s.startswith(incomplete)]
+            if current == 4 and "--api".startswith(incomplete):
+                return ["--api"]
+            if current == 5 and words[3] == "--api" and api_names is not None:
+                return [n for n in api_names if n.startswith(incomplete)]
+            # --api が位置 3 にある場合（shell より前）
+            if current == 4 and words[3] == "--api" and api_names is not None:
+                return [n for n in api_names if n.startswith(incomplete)]
+            return []
         if current >= 3 and len(words) > 2 and words[2] == "add":
             # --upgrade が未使用かつプレフィックスが一致する場合に補完候補として返す。
             # words[:current] で現在入力中のトークンを除いた使用済み単語を確認する。
@@ -343,13 +355,14 @@ _@@SAFENAME@@_completion() {
         case ${COMP_CWORD} in
             2)  COMPREPLY=($(compgen -W @@CONFIG_SUBCMDS@@ -- "$cur")) ;;
             3)  case "${COMP_WORDS[2]}" in
-                    remove|use) COMPREPLY=($(compgen -W @@API_NAMES@@ -- "$cur")) ;;
-                    add)        if [[ "$cur" == -* ]]; then
-                                    COMPREPLY=($(compgen -W '--upgrade' -- "$cur"))
-                                else
-                                    COMPREPLY=($(compgen -f -- "$cur"))
-                                    compopt -o filenames 2>/dev/null
-                                fi ;;
+                    remove|use)         COMPREPLY=($(compgen -W @@API_NAMES@@ -- "$cur")) ;;
+                    completion-script)  COMPREPLY=($(compgen -W 'bash zsh' -- "$cur")) ;;
+                    add)                if [[ "$cur" == -* ]]; then
+                                            COMPREPLY=($(compgen -W '--upgrade' -- "$cur"))
+                                        else
+                                            COMPREPLY=($(compgen -f -- "$cur"))
+                                            compopt -o filenames 2>/dev/null
+                                        fi ;;
                 esac ;;
             4)  COMPREPLY=()
                 if [[ "${COMP_WORDS[2]}" == "add" ]]; then
@@ -359,6 +372,12 @@ _@@SAFENAME@@_completion() {
                     else
                         COMPREPLY=($(compgen -W '--upgrade' -- "$cur"))
                     fi
+                elif [[ "${COMP_WORDS[2]}" == "completion-script" ]]; then
+                    COMPREPLY=($(compgen -W '--api' -- "$cur"))
+                fi ;;
+            5)  if [[ "${COMP_WORDS[2]}" == "completion-script" \
+                       && "${COMP_WORDS[4]}" == "--api" ]]; then
+                    COMPREPLY=($(compgen -W @@API_NAMES@@ -- "$cur"))
                 fi ;;
             *)  COMPREPLY=() ;;
         esac
@@ -463,12 +482,13 @@ _@@SAFENAME@@() {
             2)  _c=(@@CONFIG_SUBCMDS_ZSH@@)
                 _describe 'subcommand' _c ;;
             3)  case "${words[3]}" in
-                    remove|use) _c=(@@API_NAMES_ZSH@@); _describe 'api' _c ;;
-                    add)        if [[ "$cur" == -* ]]; then
-                                    _c=('--upgrade'); _describe 'option' _c
-                                else
-                                    _files
-                                fi ;;
+                    remove|use)         _c=(@@API_NAMES_ZSH@@); _describe 'api' _c ;;
+                    completion-script)  _c=('bash' 'zsh'); _describe 'shell' _c ;;
+                    add)                if [[ "$cur" == -* ]]; then
+                                            _c=('--upgrade'); _describe 'option' _c
+                                        else
+                                            _files
+                                        fi ;;
                 esac ;;
             4)  if [[ "${words[3]}" == "add" ]]; then
                     if [[ "${words[4]}" == "--upgrade" ]]; then
@@ -476,6 +496,11 @@ _@@SAFENAME@@() {
                     else
                         _c=('--upgrade'); _describe 'option' _c
                     fi
+                elif [[ "${words[3]}" == "completion-script" ]]; then
+                    _c=('--api'); _describe 'option' _c
+                fi ;;
+            5)  if [[ "${words[3]}" == "completion-script" && "${words[5]}" == "--api" ]]; then
+                    _c=(@@API_NAMES_ZSH@@); _describe 'api' _c
                 fi ;;
         esac
         return

--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -212,12 +212,27 @@ def completions_for_context(
     """
     incomplete = words[current] if current < len(words) else ""
 
-    # トップレベルサブコマンド名の補完
+    # トップレベルサブコマンド名と --api オプションの補完
     if current == 1:
-        return [c for c in TOP_LEVEL_COMMANDS if c.startswith(incomplete)]
+        cmds = [c for c in TOP_LEVEL_COMMANDS if c.startswith(incomplete)]
+        if "--api".startswith(incomplete):
+            cmds.append("--api")
+        return cmds
 
     if len(words) < 2:
         return []
+
+    # --api <apiname> グループオプションの処理
+    if words[1] == "--api":
+        if current == 2:
+            return [n for n in (api_names or []) if n.startswith(incomplete)]
+        # --api <apiname> をスキップして通常補完に委譲
+        if len(words) > 3:
+            words = [words[0]] + words[3:]
+            current -= 2
+            incomplete = words[current] if current < len(words) else ""
+        else:
+            return []
 
     # config サブコマンドの補完
     if words[1] == "config":
@@ -231,16 +246,17 @@ def completions_for_context(
         ):
             return [n for n in api_names if n.startswith(incomplete)]
         if current >= 3 and len(words) > 2 and words[2] == "completion-script":
-            # completion-script <shell> [--api <apiname>]
+            # completion-script [<shell>] [--api <apiname>]
             if current == 3:
-                return [s for s in ["bash", "zsh"] if s.startswith(incomplete)]
-            if current == 4 and "--api".startswith(incomplete):
+                return [s for s in ["bash", "zsh", "--api"] if s.startswith(incomplete)]
+            # --api の直後のトークンでは API 名を補完する。
+            # `completion-script bash --api <TAB>` と
+            # `completion-script --api <TAB>` の両方を位置ベースで扱う。
+            if current > 3 and words[current - 1] == "--api" and api_names is not None:
+                return [n for n in api_names if n.startswith(incomplete)]
+            # --api がまだ使われていない場合は候補として提示する
+            if "--api" not in words[:current] and "--api".startswith(incomplete):
                 return ["--api"]
-            if current == 5 and words[3] == "--api" and api_names is not None:
-                return [n for n in api_names if n.startswith(incomplete)]
-            # --api が位置 3 にある場合（shell より前）
-            if current == 4 and words[3] == "--api" and api_names is not None:
-                return [n for n in api_names if n.startswith(incomplete)]
             return []
         if current >= 3 and len(words) > 2 and words[2] == "add":
             # --upgrade が未使用かつプレフィックスが一致する場合に補完候補として返す。
@@ -345,18 +361,33 @@ _@@SAFENAME@@_completion() {
     [[ $COMP_CWORD -ge 2 ]] && pprev="${COMP_WORDS[COMP_CWORD-2]}"
 
     if [[ ${COMP_CWORD} -eq 1 ]]; then
-        COMPREPLY=($(compgen -W @@TOP_LEVEL_CMDS@@ -- "$cur"))
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W '--api' -- "$cur"))
+        else
+            COMPREPLY=($(compgen -W @@TOP_LEVEL_CMDS@@ -- "$cur"))
+        fi
         return
     fi
 
-    local cmd="${COMP_WORDS[1]}"
+    # --api <apiname> グループオプションの処理
+    local _off=0
+    if [[ "${COMP_WORDS[1]}" == "--api" ]]; then
+        if [[ ${COMP_CWORD} -eq 2 ]]; then
+            COMPREPLY=($(compgen -W @@API_NAMES@@ -- "$cur"))
+            return
+        fi
+        _off=2
+    fi
+    local _cword=$(( COMP_CWORD - _off ))
+
+    local cmd="${COMP_WORDS[$((1 + _off))]}"
 
     if [[ "$cmd" == "config" ]]; then
-        case ${COMP_CWORD} in
+        case ${_cword} in
             2)  COMPREPLY=($(compgen -W @@CONFIG_SUBCMDS@@ -- "$cur")) ;;
-            3)  case "${COMP_WORDS[2]}" in
+            3)  case "${COMP_WORDS[$((2 + _off))]}" in
                     remove|use)         COMPREPLY=($(compgen -W @@API_NAMES@@ -- "$cur")) ;;
-                    completion-script)  COMPREPLY=($(compgen -W 'bash zsh' -- "$cur")) ;;
+                    completion-script)  COMPREPLY=($(compgen -W 'bash zsh --api' -- "$cur")) ;;
                     add)                if [[ "$cur" == -* ]]; then
                                             COMPREPLY=($(compgen -W '--upgrade' -- "$cur"))
                                         else
@@ -365,18 +396,18 @@ _@@SAFENAME@@_completion() {
                                         fi ;;
                 esac ;;
             4)  COMPREPLY=()
-                if [[ "${COMP_WORDS[2]}" == "add" ]]; then
-                    if [[ "${COMP_WORDS[3]}" == "--upgrade" ]]; then
+                if [[ "${COMP_WORDS[$((2 + _off))]}" == "add" ]]; then
+                    if [[ "${COMP_WORDS[$((3 + _off))]}" == "--upgrade" ]]; then
                         COMPREPLY=($(compgen -f -- "$cur"))
                         compopt -o filenames 2>/dev/null
                     else
                         COMPREPLY=($(compgen -W '--upgrade' -- "$cur"))
                     fi
-                elif [[ "${COMP_WORDS[2]}" == "completion-script" ]]; then
+                elif [[ "${COMP_WORDS[$((2 + _off))]}" == "completion-script" ]]; then
                     COMPREPLY=($(compgen -W '--api' -- "$cur"))
                 fi ;;
-            5)  if [[ "${COMP_WORDS[2]}" == "completion-script" \
-                       && "${COMP_WORDS[4]}" == "--api" ]]; then
+            5)  if [[ "${COMP_WORDS[$((2 + _off))]}" == "completion-script" \
+                       && "$prev" == "--api" ]]; then
                     COMPREPLY=($(compgen -W @@API_NAMES@@ -- "$cur"))
                 fi ;;
             *)  COMPREPLY=() ;;
@@ -384,15 +415,15 @@ _@@SAFENAME@@_completion() {
         return
     fi
 
-    if [[ "$cmd" == "summary" && ${COMP_CWORD} -eq 2 ]]; then
+    if [[ "$cmd" == "summary" && ${_cword} -eq 2 ]]; then
         COMPREPLY=($(compgen -W @@SUMMARY_OPTS@@ -- "$cur"))
         return
     fi
 
     if [[ "$cmd" == "spec" ]]; then
-        if [[ ${COMP_CWORD} -eq 2 ]]; then
+        if [[ ${_cword} -eq 2 ]]; then
             COMPREPLY=($(compgen -W @@SPEC_OPTS@@ -- "$cur"))
-        elif [[ ${COMP_CWORD} -eq 3 && "${COMP_WORDS[2]}" == "--full" ]]; then
+        elif [[ ${_cword} -eq 3 && "${COMP_WORDS[$((2 + _off))]}" == "--full" ]]; then
             COMPREPLY=($(compgen -W @@ALL_RESOURCES@@ -- "$cur"))
         fi
         return
@@ -400,14 +431,14 @@ _@@SAFENAME@@_completion() {
 
     case "$cmd" in get|post|put|patch|delete) ;; *) return ;; esac
 
-    if [[ ${COMP_CWORD} -eq 2 ]]; then
+    if [[ ${_cword} -eq 2 ]]; then
         case "$cmd" in
 @@METHOD_RESOURCE_CASES@@
         esac
         return
     fi
 
-    local resource="${COMP_WORDS[2]}"
+    local resource="${COMP_WORDS[$((2 + _off))]}"
     local ctx="${cmd}:${resource}"
 
     # ここから extglob パターン（+([^ /])）を使う case 文があるため extglob を有効化する。
@@ -471,52 +502,69 @@ _@@SAFENAME@@() {
     local -a _c
 
     if [[ $cword -eq 1 ]]; then
-        _c=(@@TOP_LEVEL_CMDS_ZSH@@)
-        _describe 'command' _c && return
+        if [[ "$cur" == -* ]]; then
+            _c=('--api'); _describe 'option' _c
+        else
+            _c=(@@TOP_LEVEL_CMDS_ZSH@@)
+            _describe 'command' _c
+        fi
+        return
     fi
 
-    local cmd="${words[2]}"
+    # --api <apiname> グループオプションの処理
+    local _off=0
+    if [[ "${words[2]}" == "--api" ]]; then
+        if [[ $cword -eq 2 ]]; then
+            _c=(@@API_NAMES_ZSH@@); _describe 'api' _c
+            return
+        fi
+        _off=2
+    fi
+    local _cword=$(( cword - _off ))
+
+    local cmd="${words[$((2 + _off))]}"
 
     if [[ "$cmd" == "config" ]]; then
-        case $cword in
+        case $_cword in
             2)  _c=(@@CONFIG_SUBCMDS_ZSH@@)
                 _describe 'subcommand' _c ;;
-            3)  case "${words[3]}" in
+            3)  case "${words[$((3 + _off))]}" in
                     remove|use)         _c=(@@API_NAMES_ZSH@@); _describe 'api' _c ;;
-                    completion-script)  _c=('bash' 'zsh'); _describe 'shell' _c ;;
+                    completion-script)  _c=('bash' 'zsh' '--api'); _describe 'shell' _c ;;
                     add)                if [[ "$cur" == -* ]]; then
                                             _c=('--upgrade'); _describe 'option' _c
                                         else
                                             _files
                                         fi ;;
                 esac ;;
-            4)  if [[ "${words[3]}" == "add" ]]; then
-                    if [[ "${words[4]}" == "--upgrade" ]]; then
+            4)  if [[ "${words[$((3 + _off))]}" == "add" ]]; then
+                    if [[ "${words[$((4 + _off))]}" == "--upgrade" ]]; then
                         _files
                     else
                         _c=('--upgrade'); _describe 'option' _c
                     fi
-                elif [[ "${words[3]}" == "completion-script" ]]; then
+                elif [[ "${words[$((3 + _off))]}" == "completion-script" ]]; then
                     _c=('--api'); _describe 'option' _c
                 fi ;;
-            5)  if [[ "${words[3]}" == "completion-script" && "${words[5]}" == "--api" ]]; then
+            5)  if [[ "${words[$((3 + _off))]}" == "completion-script" \
+                       && "$prev" == "--api" ]]; then
                     _c=(@@API_NAMES_ZSH@@); _describe 'api' _c
                 fi ;;
         esac
         return
     fi
 
-    if [[ "$cmd" == "summary" && $cword -eq 2 ]]; then
+    if [[ "$cmd" == "summary" && $_cword -eq 2 ]]; then
         _c=(--csv @@ALL_RESOURCES_ZSH@@)
         _describe 'resource' _c
         return
     fi
 
     if [[ "$cmd" == "spec" ]]; then
-        if [[ $cword -eq 2 ]]; then
+        if [[ $_cword -eq 2 ]]; then
             _c=(--full @@ALL_RESOURCES_ZSH@@)
             _describe 'resource' _c
-        elif [[ $cword -eq 3 && "${words[3]}" == "--full" ]]; then
+        elif [[ $_cword -eq 3 && "${words[$((3 + _off))]}" == "--full" ]]; then
             _c=(@@ALL_RESOURCES_ZSH@@)
             _describe 'resource' _c
         fi
@@ -525,14 +573,14 @@ _@@SAFENAME@@() {
 
     case "$cmd" in get|post|put|patch|delete) ;; *) return ;; esac
 
-    if [[ $cword -eq 2 ]]; then
+    if [[ $_cword -eq 2 ]]; then
         case "$cmd" in
 @@ZSH_METHOD_RESOURCE_CASES@@
         esac
         return
     fi
 
-    local resource="${words[3]}"
+    local resource="${words[$((3 + _off))]}"
     local ctx="${cmd}:${resource}"
 
     if [[ "$prev" == "-q" ]]; then

--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -231,6 +231,12 @@ def completions_for_context(
             words = [words[0]] + words[3:]
             current -= 2
             incomplete = words[current] if current < len(words) else ""
+            # シフト後に current == 1 になった場合はトップレベル補完を返す
+            if current == 1:
+                cmds = [c for c in TOP_LEVEL_COMMANDS if c.startswith(incomplete)]
+                if "--api".startswith(incomplete):
+                    cmds.append("--api")
+                return cmds
         else:
             return []
 

--- a/src/papycli/completion.py
+++ b/src/papycli/completion.py
@@ -263,6 +263,9 @@ def completions_for_context(
             # --api がまだ使われていない場合は候補として提示する
             if "--api" not in words[:current] and "--api".startswith(incomplete):
                 return ["--api"]
+            # シェル (bash/zsh) がまだ指定されていない場合は補完する
+            if not any(s in words[3:current] for s in ("bash", "zsh")):
+                return [s for s in ["bash", "zsh"] if s.startswith(incomplete)]
             return []
         if current >= 3 and len(words) > 2 and words[2] == "add":
             # --upgrade が未使用かつプレフィックスが一致する場合に補完候補として返す。

--- a/src/papycli/config.py
+++ b/src/papycli/config.py
@@ -147,8 +147,12 @@ def load_apidef_by_name(
     api_entry = conf.get(api_name)
     if not isinstance(api_entry, dict):
         raise RuntimeError(f"Invalid configuration for API '{api_name}'.")
-    base_url = str(api_entry.get("url", ""))
-    apidef_filename = str(api_entry.get("apidef", f"{api_name}.json"))
+    url_value = api_entry.get("url", "")
+    base_url = url_value if isinstance(url_value, str) else ""
+    apidef_value = api_entry.get("apidef", f"{api_name}.json")
+    apidef_filename = (
+        apidef_value if isinstance(apidef_value, str) and apidef_value else f"{api_name}.json"
+    )
     apidef_path = get_apis_dir(resolved_dir) / apidef_filename
     if not apidef_path.exists():
         raise RuntimeError(

--- a/src/papycli/config.py
+++ b/src/papycli/config.py
@@ -115,29 +115,6 @@ def get_default_api(conf: dict[str, Any]) -> str | None:
     return None
 
 
-def get_aliases(conf: dict[str, Any]) -> dict[str, str]:
-    """エイリアス名 → スペック名のマッピングを返す。未設定の場合は空の dict。"""
-    value = conf.get("aliases")
-    if isinstance(value, dict):
-        return {k: v for k, v in value.items() if isinstance(k, str) and isinstance(v, str)}
-    return {}
-
-
-def set_alias(conf: dict[str, Any], alias_name: str, spec_name: str) -> None:
-    """エイリアスを設定する。"""
-    if "aliases" not in conf or not isinstance(conf["aliases"], dict):
-        conf["aliases"] = {}
-    conf["aliases"][alias_name] = spec_name
-
-
-def remove_alias(conf: dict[str, Any], alias_name: str) -> None:
-    """エイリアスを削除する。存在しない場合は何もしない。"""
-    aliases = conf.get("aliases")
-    if isinstance(aliases, dict):
-        aliases.pop(alias_name, None)
-        if not aliases:
-            conf.pop("aliases")
-
 
 def get_logfile(conf: dict[str, Any]) -> str | None:
     """現在のログファイルパスを返す。未設定・空文字列・非文字列の場合は None。"""
@@ -155,6 +132,32 @@ def set_logfile(conf: dict[str, Any], path: str) -> None:
 def unset_logfile(conf: dict[str, Any]) -> None:
     """ログファイル設定を削除する（ログ無効化）。"""
     conf.pop("logfile", None)
+
+
+def load_apidef_by_name(
+    api_name: str,
+    conf_dir: Path | None = None,
+    *,
+    conf: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], str]:
+    """指定した API 名の (apidef dict, base_url) を返す。"""
+    resolved_dir = conf_dir or get_conf_dir()
+    if conf is None:
+        conf = load_conf(resolved_dir)
+    api_entry = conf.get(api_name)
+    if not isinstance(api_entry, dict):
+        raise RuntimeError(f"Invalid configuration for API '{api_name}'.")
+    base_url = str(api_entry.get("url", ""))
+    apidef_filename = str(api_entry.get("apidef", f"{api_name}.json"))
+    apidef_path = get_apis_dir(resolved_dir) / apidef_filename
+    if not apidef_path.exists():
+        raise RuntimeError(
+            f"API definition file not found: {apidef_path}\n"
+            "Run 'papycli config add <spec>' to regenerate it."
+        )
+    with apidef_path.open(encoding="utf-8") as f:
+        apidef: dict[str, Any] = json.load(f)
+    return apidef, base_url
 
 
 def load_current_apidef(

--- a/src/papycli/main.py
+++ b/src/papycli/main.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -17,18 +16,16 @@ from papycli.api_call import call_api, match_path_template
 from papycli.checker import check_request
 from papycli.completion import _SAFE_CMD_RE, generate_static_script, get_completions
 from papycli.config import (
-    get_aliases,
     get_apis_dir,
     get_conf_dir,
     get_conf_path,
     get_logfile,
+    load_apidef_by_name,
     load_conf,
     load_current_apidef,
     load_current_raw_spec,
-    remove_alias,
     remove_api,
     save_conf,
-    set_alias,
     set_api_override,
     set_default_api,
     set_logfile,
@@ -49,21 +46,16 @@ from papycli.summary import format_endpoint_detail, format_summary_csv, print_su
     ),
 )
 @click.version_option(__version__, "-V", "--version")
+@click.option(
+    "--api", "api_name", default=None, metavar="API_NAME",
+    help=h(
+        "Use the specified API instead of the default.",
+        "デフォルトの代わりに指定した API を使用する。",
+    ),
+)
 @click.pass_context
-def cli(ctx: click.Context) -> None:
-    # 毎回リセットしてからエイリアス検出する（繰り返し呼び出し時のグローバル汚染を防ぐ）
-    set_api_override(None)
-    # ctx.info_name は CliRunner/実シェルいずれでも正確な呼び出しコマンド名を返す
-    # .stem で Windows の ".exe" 等を除去する
-    cmd_name = Path(ctx.info_name or "").stem
-    if cmd_name != "papycli":
-        try:
-            _conf = load_conf(get_conf_dir())
-            _aliases = get_aliases(_conf)
-            if cmd_name in _aliases:
-                set_api_override(_aliases[cmd_name])
-        except Exception as e:
-            click.echo(f"Warning: alias detection failed: {e}", err=True)
+def cli(ctx: click.Context, api_name: str | None) -> None:
+    set_api_override(api_name)
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
 
@@ -361,21 +353,30 @@ def cmd_config_log(path: str | None, unset: bool) -> None:
     help=h(
         'Print a shell completion script.\n\n'
         'Usage (bash): eval "$(papycli config completion-script bash)"\n\n'
-        'Usage (zsh):  eval "$(papycli config completion-script zsh)"',
+        'Usage (zsh):  eval "$(papycli config completion-script zsh)"\n\n'
+        'To generate completion for a shell alias (e.g. alias redmine=\'papycli --api redmine\'):\n'
+        '  eval "$(papycli config completion-script --api redmine bash)"',
         'シェル補完スクリプトを出力する。\n\n'
         '使い方 (bash): eval "$(papycli config completion-script bash)"\n\n'
-        '使い方 (zsh):  eval "$(papycli config completion-script zsh)"',
+        '使い方 (zsh):  eval "$(papycli config completion-script zsh)"\n\n'
+        'シェルエイリアス用補完スクリプト（例: alias redmine=\'papycli --api redmine\'）:\n'
+        '  eval "$(papycli config completion-script --api redmine bash)"',
     ),
 )
 @click.argument("shell", type=click.Choice(["bash", "zsh"]))
-def cmd_config_completion_script(shell: str) -> None:
-    # find_root().info_name でエイリアス経由でも正確なコマンド名を取得する
-    root_name = click.get_current_context().find_root().info_name or ""
-    cmd_name = Path(root_name).stem  # .stem で Windows の ".exe" 等を除去する
+@click.option(
+    "--api", "api_name", default=None, metavar="API_NAME",
+    help=h(
+        "Generate completion for the specified API name as the command name.",
+        "指定した API 名をコマンド名とする補完スクリプトを生成する。",
+    ),
+)
+def cmd_config_completion_script(shell: str, api_name: str | None) -> None:
     conf_dir = get_conf_dir()
+    conf: dict[str, Any] | None = None
     api_names: list[str] = []
     apidef = None
-    conf: dict[str, Any] | None = None
+
     try:
         conf = load_conf(conf_dir)
         api_names = [
@@ -383,188 +384,46 @@ def cmd_config_completion_script(shell: str) -> None:
         ]
     except Exception as e:
         click.echo(f"Warning: failed to load configuration for completion: {e}", err=True)
-    # デフォルト API が設定されている場合のみ apidef を読み込む。
-    # 未設定・設定ファイル未作成は通常ケースのため警告なしでスキップする。
-    if conf is not None and isinstance(conf.get("default"), str) and conf.get("default"):
-        try:
-            apidef, _ = load_current_apidef(conf_dir, conf=conf)
-        except Exception as e:
+
+    if api_name is not None:
+        # --api 指定時: 指定した API 名をコマンド名とし、その API の apidef を使用する
+        if not _SAFE_CMD_RE.match(api_name):
             click.echo(
-                f"Warning: failed to load current API definition for completion: {e}", err=True
+                f"Error: API name '{api_name}' is invalid. "
+                "Must start with a letter or digit, and contain only"
+                " letters, digits, hyphens, and underscores.",
+                err=True,
             )
+            sys.exit(1)
+        if api_name not in api_names:
+            click.echo(f"Error: API '{api_name}' is not registered.", err=True)
+            sys.exit(1)
+        cmd_name = api_name
+        try:
+            apidef, _ = load_apidef_by_name(api_name, conf_dir, conf=conf)
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            sys.exit(1)
+    else:
+        # --api 未指定時: 呼び出しコマンド名を使用し、デフォルト API の apidef を使用する
+        root_name = click.get_current_context().find_root().info_name or ""
+        cmd_name = Path(root_name).stem  # .stem で Windows の ".exe" 等を除去する
+        # デフォルト API が設定されている場合のみ apidef を読み込む。
+        # 未設定・設定ファイル未作成は通常ケースのため警告なしでスキップする。
+        if conf is not None and isinstance(conf.get("default"), str) and conf.get("default"):
+            try:
+                apidef, _ = load_current_apidef(conf_dir, conf=conf)
+            except Exception as e:
+                click.echo(
+                    f"Warning: failed to load current API definition for completion: {e}", err=True
+                )
+
     try:
         click.echo(generate_static_script(shell, cmd_name, apidef, api_names), nl=False)
     except ValueError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
-
-@cmd_config.command(
-    "alias",
-    help=h(
-        "Create, list, or delete command aliases.\n\n"
-        "ALIAS_NAME: the new command name (e.g. 'petcli').\n"
-        "SPEC_NAME: registered API spec name (defaults to current default).\n\n"
-        "Omit both arguments to list configured aliases.\n"
-        "Use -d ALIAS_NAME to delete an alias.",
-        "コマンドエイリアスの作成・一覧・削除を行う。\n\n"
-        "ALIAS_NAME: 新しいコマンド名（例: 'petcli'）。\n"
-        "SPEC_NAME: 登録済みスペック名（省略時は現在のデフォルト）。\n\n"
-        "両引数を省略するとエイリアス一覧を表示する。\n"
-        "-d ALIAS_NAME でエイリアスを削除する。",
-    ),
-)
-@click.argument("alias_name", required=False, default=None)
-@click.argument("spec_name", required=False, default=None)
-@click.option(
-    "-d", "delete", is_flag=True,
-    help=h("Delete the specified alias.", "指定したエイリアスを削除する。"),
-)
-def cmd_config_alias(
-    alias_name: str | None,
-    spec_name: str | None,
-    delete: bool,
-) -> None:
-    conf_dir = get_conf_dir()
-    conf = load_conf(conf_dir)
-
-    # alias_name が指定されている場合は安全な名前かチェックする
-    if alias_name is not None and not _SAFE_CMD_RE.match(alias_name):
-        click.echo(
-            f"Error: alias name '{alias_name}' is invalid. "
-            "Must start with a letter or digit, and contain only"
-            " letters, digits, hyphens, and underscores.",
-            err=True,
-        )
-        sys.exit(1)
-
-    # -d: エイリアスを削除する
-    if delete:
-        if alias_name is None:
-            click.echo("Error: alias name is required with -d.", err=True)
-            sys.exit(1)
-        if spec_name is not None:
-            click.echo("Error: SPEC_NAME cannot be specified with -d.", err=True)
-            sys.exit(1)
-        raw_aliases = conf.get("aliases")
-        if not isinstance(raw_aliases, dict) or alias_name not in raw_aliases:
-            click.echo(f"Error: alias '{alias_name}' not found.", err=True)
-            sys.exit(1)
-        # symlink を先に削除し、失敗時は config を変更せずに終了する
-        symlink = conf_dir / "bin" / alias_name
-        if symlink.is_symlink():
-            try:
-                symlink.unlink()
-            except OSError as e:
-                click.echo(f"Error: failed to remove symlink: {e}", err=True)
-                sys.exit(1)
-        elif symlink.exists():
-            click.echo(
-                f"Error: '{symlink}' is not a symlink created by papycli. "
-                "Remove it manually before deleting the alias.",
-                err=True,
-            )
-            sys.exit(1)
-        remove_alias(conf, alias_name)
-        save_conf(conf, conf_dir)
-        click.echo(f"Alias '{alias_name}' removed.")
-        return
-
-    # 引数なし: エイリアス一覧を表示する
-    if alias_name is None:
-        aliases = get_aliases(conf)
-        if not aliases:
-            click.echo("(no aliases configured)")
-        else:
-            for name, spec in aliases.items():
-                click.echo(f"{name} -> {spec}")
-        return
-
-    # SPEC_NAME 省略時は config の default を使用する。
-    # エイリアス呼び出し時のオーバーライドを避けるため get_default_api は使わず
-    # config dict を直接参照する。
-    if spec_name is None:
-        raw_default = conf.get("default")
-        if not isinstance(raw_default, str) or not raw_default:
-            click.echo(
-                "Error: no SPEC_NAME given and no default API configured.", err=True
-            )
-            sys.exit(1)
-        spec_name = raw_default
-
-    # スペックが登録済みかチェックする（予約済みキーは除外）
-    _reserved = ("default", "aliases")
-    if spec_name in _reserved or not isinstance(conf.get(spec_name), dict):
-        click.echo(f"Error: spec '{spec_name}' is not registered.", err=True)
-        sys.exit(1)
-
-    # papycli 実行ファイルのパスを解決する。
-    # エイリアス経由で呼び出された場合（例: petcli config alias ...）は "papycli" が
-    # PATH に直接なくても、現在のコマンド名で再試行してシンボリックリンクを辿る。
-    root_info_name = click.get_current_context().find_root().info_name or ""
-    papycli_path = shutil.which("papycli") or shutil.which(Path(root_info_name).stem)
-    if papycli_path is None:
-        click.echo(
-            "Error: cannot locate the papycli executable in PATH. "
-            "Ensure papycli is installed and available on your PATH.",
-            err=True,
-        )
-        sys.exit(1)
-    papycli_exe = Path(papycli_path).resolve()
-    if papycli_exe.stem != "papycli":
-        click.echo(
-            f"Error: resolved executable '{papycli_exe}' does not appear to be papycli. "
-            "Ensure 'papycli' is available on your PATH.",
-            err=True,
-        )
-        sys.exit(1)
-
-    # ~/.papycli/bin/<alias_name> -> papycli 実行ファイルへの symlink を先に作成する。
-    # 失敗した場合は config を変更せずにエラー終了する。
-    bin_dir = conf_dir / "bin"
-    try:
-        bin_dir.mkdir(parents=True, exist_ok=True)
-        symlink = bin_dir / alias_name
-        if symlink.is_symlink():
-            symlink.unlink()
-        elif symlink.exists():
-            click.echo(
-                f"Error: '{symlink}' already exists and is not a symlink. "
-                "Remove it manually to create the alias.",
-                err=True,
-            )
-            sys.exit(1)
-        symlink.symlink_to(papycli_exe)
-    except OSError as e:
-        msg = f"Error: failed to create symlink: {e}"
-        if sys.platform == "win32":
-            msg += (
-                "\nOn Windows, symlink creation requires either Developer Mode "
-                "(Settings → For developers → Developer Mode) or running as Administrator. "
-                "Note: even with symlinks enabled, extensionless commands are not resolved "
-                "by default on Windows (PATHEXT does not include entries without extensions). "
-                "Consider using WSL or Git Bash for alias functionality."
-            )
-        click.echo(msg, err=True)
-        sys.exit(1)
-
-    # symlink 作成後に config を保存する（失敗時は symlink を rollback する）
-    # OSError 以外（json.dump の TypeError/ValueError 等）も捕捉して一貫性を保つ
-    try:
-        set_alias(conf, alias_name, spec_name)
-        save_conf(conf, conf_dir)
-    except Exception as e:
-        symlink.unlink(missing_ok=True)
-        click.echo(f"Error: failed to save config: {e}", err=True)
-        sys.exit(1)
-
-    click.echo(f"Alias '{alias_name}' -> '{spec_name}' created.")
-    click.echo(f"Symlink: {symlink} -> {papycli_exe}")
-    click.echo("\nAdd the following to your shell profile if not already set:")
-    click.echo(f'  export PATH="{bin_dir}:$PATH"')
-    click.echo(f"\nEnable shell completion for '{alias_name}':")
-    click.echo(f'  eval "$({alias_name} config completion-script bash)"  # bash')
-    click.echo(f'  eval "$({alias_name} config completion-script zsh)"   # zsh')
 
 
 # ---------------------------------------------------------------------------

--- a/src/papycli/main.py
+++ b/src/papycli/main.py
@@ -383,6 +383,9 @@ def cmd_config_completion_script(shell: str, api_name: str | None) -> None:
             k for k in conf if k not in ("default", "aliases") and isinstance(conf[k], dict)
         ]
     except Exception as e:
+        if api_name is not None:
+            click.echo(f"Error: failed to load configuration: {e}", err=True)
+            sys.exit(1)
         click.echo(f"Warning: failed to load configuration for completion: {e}", err=True)
 
     if api_name is not None:

--- a/tests/unittest/test_completion.py
+++ b/tests/unittest/test_completion.py
@@ -175,7 +175,6 @@ def test_complete_config_subcommands_prefix() -> None:
 def test_complete_config_subcommands_covers_all() -> None:
     assert set(CONFIG_SUBCOMMANDS) == {
         "add",
-        "alias",
         "completion-script",
         "list",
         "log",

--- a/tests/unittest/test_config.py
+++ b/tests/unittest/test_config.py
@@ -1,13 +1,11 @@
 """config モジュールのテスト."""
 
 import json
-import os
 from pathlib import Path
 
 import pytest
 
 from papycli.config import (
-    get_aliases,
     get_apis_dir,
     get_conf_dir,
     get_conf_path,
@@ -16,10 +14,8 @@ from papycli.config import (
     load_conf,
     load_current_raw_spec,
     register_api,
-    remove_alias,
     remove_api,
     save_conf,
-    set_alias,
     set_api_override,
     set_default_api,
     set_logfile,
@@ -247,55 +243,6 @@ def test_load_current_raw_spec_missing_file(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="Raw spec file not found"):
         load_current_raw_spec(tmp_path)
 
-
-# ---------------------------------------------------------------------------
-# aliases
-# ---------------------------------------------------------------------------
-
-
-def test_get_aliases_empty_when_not_set() -> None:
-    assert get_aliases({}) == {}
-
-
-def test_get_aliases_returns_mapping() -> None:
-    conf: dict = {"aliases": {"petcli": "petstore"}}
-    assert get_aliases(conf) == {"petcli": "petstore"}
-
-
-def test_get_aliases_ignores_non_string_values() -> None:
-    conf: dict = {"aliases": {"petcli": "petstore", "bad": 123}}
-    assert get_aliases(conf) == {"petcli": "petstore"}
-
-
-def test_set_alias_creates_aliases_key() -> None:
-    conf: dict = {}
-    set_alias(conf, "petcli", "petstore")
-    assert conf["aliases"] == {"petcli": "petstore"}
-
-
-def test_set_alias_adds_to_existing() -> None:
-    conf: dict = {"aliases": {"mycli": "api1"}}
-    set_alias(conf, "petcli", "petstore")
-    assert conf["aliases"] == {"mycli": "api1", "petcli": "petstore"}
-
-
-def test_remove_alias_removes_entry() -> None:
-    conf: dict = {"aliases": {"petcli": "petstore", "mycli": "api1"}}
-    remove_alias(conf, "petcli")
-    assert "petcli" not in conf["aliases"]
-    assert "mycli" in conf["aliases"]
-
-
-def test_remove_alias_removes_aliases_key_when_empty() -> None:
-    conf: dict = {"aliases": {"petcli": "petstore"}}
-    remove_alias(conf, "petcli")
-    assert "aliases" not in conf
-
-
-def test_remove_alias_noop_when_not_found() -> None:
-    conf: dict = {"aliases": {"petcli": "petstore"}}
-    remove_alias(conf, "nonexistent")
-    assert conf == {"aliases": {"petcli": "petstore"}}
 
 
 def test_get_default_api_uses_override(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unittest/test_main.py
+++ b/tests/unittest/test_main.py
@@ -1495,7 +1495,8 @@ def test_api_option_sets_override(
 
     monkeypatch.setattr(_main, "set_api_override", _capture)
     runner = CliRunner()
-    runner.invoke(cli, ["--api", "petstore-oas3", "summary"])
+    result = runner.invoke(cli, ["--api", "petstore-oas3", "summary"])
+    assert result.exit_code == 0
     assert "petstore-oas3" in overrides
 
 

--- a/tests/unittest/test_main.py
+++ b/tests/unittest/test_main.py
@@ -1352,184 +1352,6 @@ def test_config_log_unset_and_path_exclusive(
     assert "Error" in result.output or "Error" in (result.stderr if hasattr(result, "stderr") else "")
 
 
-# ---------------------------------------------------------------------------
-# config alias
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def alias_conf_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """petstore-oas3.json を登録した conf_dir を返す（alias テスト用）。"""
-    if not PETSTORE_PATH.exists():
-        pytest.skip("petstore-oas3.json not found")
-    monkeypatch.setenv("PAPYCLI_CONF_DIR", str(tmp_path))
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "add", str(PETSTORE_PATH)])
-    assert result.exit_code == 0, f"config add failed: {result.output}"
-    return tmp_path
-
-
-@pytest.fixture(scope="session")
-def symlinks_supported(tmp_path_factory: pytest.TempPathFactory) -> bool:
-    """セッションスコープで symlink が使えるか確認する。"""
-    p = tmp_path_factory.mktemp("symlink_check")
-    try:
-        (p / "link").symlink_to(p / "target")
-        (p / "link").unlink()
-        return True
-    except (OSError, NotImplementedError):
-        return False
-
-
-def test_config_alias_list_empty(alias_conf_dir: Path) -> None:
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "alias"])
-    assert result.exit_code == 0
-    assert "no aliases" in result.output
-
-
-def test_config_alias_create(
-    alias_conf_dir: Path, symlinks_supported: bool,
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-) -> None:
-    if not symlinks_supported:
-        pytest.skip("symlinks not supported on this platform")
-    import json as _json
-    import papycli.main as _main
-
-    fake_exe = tmp_path / "papycli"
-    fake_exe.touch()
-    monkeypatch.setattr(_main.shutil, "which", lambda name: str(fake_exe))
-
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "alias", "petcli", "petstore-oas3"])
-    assert result.exit_code == 0, result.output
-    assert "petcli" in result.output
-
-    conf = _json.loads((alias_conf_dir / "papycli.conf").read_text(encoding="utf-8"))
-    assert conf.get("aliases", {}).get("petcli") == "petstore-oas3"
-    symlink = alias_conf_dir / "bin" / "petcli"
-    assert symlink.is_symlink()
-    assert symlink.resolve() == fake_exe.resolve()
-
-
-def test_config_alias_create_defaults_to_default_spec(
-    alias_conf_dir: Path, symlinks_supported: bool,
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-) -> None:
-    if not symlinks_supported:
-        pytest.skip("symlinks not supported on this platform")
-    import json as _json
-    import papycli.main as _main
-
-    fake_exe = tmp_path / "papycli"
-    fake_exe.touch()
-    monkeypatch.setattr(_main.shutil, "which", lambda name: str(fake_exe))
-
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "alias", "petcli"])
-    assert result.exit_code == 0, result.output
-
-    conf = _json.loads((alias_conf_dir / "papycli.conf").read_text(encoding="utf-8"))
-    default_spec = conf.get("default")
-    assert conf.get("aliases", {}).get("petcli") == default_spec
-    symlink = alias_conf_dir / "bin" / "petcli"
-    assert symlink.is_symlink()
-    assert symlink.resolve() == fake_exe.resolve()
-
-
-def test_config_alias_list_shows_aliases(alias_conf_dir: Path) -> None:
-    import json as _json
-    # config alias コマンド（symlink 作成を伴う）を使わず conf を直接書き換えてリスト表示を検証する
-    conf_path = alias_conf_dir / "papycli.conf"
-    conf = _json.loads(conf_path.read_text(encoding="utf-8"))
-    conf.setdefault("aliases", {})["petcli"] = "petstore-oas3"
-    conf_path.write_text(_json.dumps(conf, ensure_ascii=False), encoding="utf-8")
-
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "alias"])
-    assert result.exit_code == 0
-    assert "petcli" in result.output
-    assert "petstore-oas3" in result.output
-
-
-def test_config_alias_delete(
-    alias_conf_dir: Path, symlinks_supported: bool,
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-) -> None:
-    if not symlinks_supported:
-        pytest.skip("symlinks not supported on this platform")
-    import json as _json
-    import papycli.main as _main
-
-    fake_exe = tmp_path / "papycli"
-    fake_exe.touch()
-    monkeypatch.setattr(_main.shutil, "which", lambda name: str(fake_exe))
-
-    runner = CliRunner()
-    runner.invoke(cli, ["config", "alias", "petcli", "petstore-oas3"])
-    result = runner.invoke(cli, ["config", "alias", "-d", "petcli"])
-    assert result.exit_code == 0
-    assert "removed" in result.output
-
-    conf = _json.loads((alias_conf_dir / "papycli.conf").read_text(encoding="utf-8"))
-    assert "petcli" not in conf.get("aliases", {})
-    assert not (alias_conf_dir / "bin" / "petcli").exists()
-
-
-def test_config_alias_delete_nonexistent(alias_conf_dir: Path) -> None:
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "alias", "-d", "nonexistent"])
-    assert result.exit_code != 0
-    assert "not found" in result.output
-
-
-def test_config_alias_unknown_spec(alias_conf_dir: Path) -> None:
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "alias", "petcli", "no-such-spec"])
-    assert result.exit_code != 0
-    assert "not registered" in result.output
-
-
-def test_config_alias_delete_requires_name(alias_conf_dir: Path) -> None:
-    runner = CliRunner()
-    result = runner.invoke(cli, ["config", "alias", "-d"])
-    assert result.exit_code != 0
-    assert "alias name is required" in result.output
-
-
-def test_alias_detection_sets_api_override(
-    alias_conf_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """argv[0] がエイリアス名と一致するとき、対応する spec が set_api_override で設定される。"""
-    import json as _json
-    import papycli.main as _main
-
-    # config alias コマンド（symlink 作成を伴う）を使わず conf を直接書き換える
-    conf_path = alias_conf_dir / "papycli.conf"
-    conf = _json.loads(conf_path.read_text(encoding="utf-8"))
-    conf.setdefault("aliases", {})["petcli"] = "petstore-oas3"
-    conf_path.write_text(_json.dumps(conf, ensure_ascii=False), encoding="utf-8")
-
-    overrides: list[str | None] = []
-    original = _main.set_api_override
-
-    def _capture(name: str | None) -> None:
-        original(name)
-        overrides.append(name)
-
-    # main.py は `from papycli.config import set_api_override` でインポートしているため、
-    # main モジュール上の名前をパッチする
-    monkeypatch.setattr(_main, "set_api_override", _capture)
-
-    runner = CliRunner()
-    result = runner.invoke(cli, ["summary"], prog_name="petcli")
-    assert result.exit_code == 0
-
-    # set_api_override が "petstore-oas3" で呼ばれていること
-    assert "petstore-oas3" in overrides
-
-
 class TestCompletionScriptStatic:
     def test_bash_no_python_call(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """生成スクリプトに _complete 呼び出しが含まれないこと。"""
@@ -1649,3 +1471,85 @@ class TestMain:
             main()
 
         assert call_order == ["load", "cli"]
+
+
+# ---------------------------------------------------------------------------
+# --api オプション
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not PETSTORE_PATH.exists(), reason="petstore-oas3.json not found")
+def test_api_option_sets_override(
+    petstore_conf_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--api <name> で指定した API が set_api_override に渡されること。"""
+    import papycli.main as _main
+
+    monkeypatch.setenv("PAPYCLI_CONF_DIR", str(petstore_conf_dir))
+    overrides: list[str | None] = []
+    original = _main.set_api_override
+
+    def _capture(name: str | None) -> None:
+        original(name)
+        overrides.append(name)
+
+    monkeypatch.setattr(_main, "set_api_override", _capture)
+    runner = CliRunner()
+    runner.invoke(cli, ["--api", "petstore-oas3", "summary"])
+    assert "petstore-oas3" in overrides
+
+
+@pytest.mark.skipif(not PETSTORE_PATH.exists(), reason="petstore-oas3.json not found")
+def test_api_option_overrides_default(
+    petstore_conf_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--api で存在しない API を指定するとエラーになること。"""
+    import responses as rsps
+
+    monkeypatch.setenv("PAPYCLI_CONF_DIR", str(petstore_conf_dir))
+    runner = CliRunner()
+    with rsps.RequestsMock():
+        result = runner.invoke(cli, ["--api", "no-such-api", "get", "/pet/1"])
+    assert result.exit_code != 0
+    assert "no-such-api" in result.output
+
+
+@pytest.mark.skipif(not PETSTORE_PATH.exists(), reason="petstore-oas3.json not found")
+class TestCompletionScriptWithApi:
+    def test_bash_uses_api_name_as_cmd(
+        self, petstore_conf_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--api 指定時はその API 名がコマンド名として補完スクリプトに埋め込まれること。"""
+        monkeypatch.setenv("PAPYCLI_CONF_DIR", str(petstore_conf_dir))
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["config", "completion-script", "bash", "--api", "petstore-oas3"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "_petstore_oas3_completion()" in result.output
+        assert "complete" in result.output
+        assert "petstore-oas3" in result.output
+
+    def test_zsh_uses_api_name_as_cmd(
+        self, petstore_conf_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--api 指定時は zsh でも API 名がコマンド名として補完スクリプトに埋め込まれること。"""
+        monkeypatch.setenv("PAPYCLI_CONF_DIR", str(petstore_conf_dir))
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["config", "completion-script", "zsh", "--api", "petstore-oas3"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "compdef _petstore_oas3 petstore-oas3" in result.output
+
+    def test_unknown_api_fails(
+        self, petstore_conf_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--api で存在しない API を指定するとエラーになること。"""
+        monkeypatch.setenv("PAPYCLI_CONF_DIR", str(petstore_conf_dir))
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["config", "completion-script", "bash", "--api", "no-such-api"]
+        )
+        assert result.exit_code != 0
+        assert "no-such-api" in result.output


### PR DESCRIPTION
Closes #193

## Summary

- `papycli --api <apiname>` グループレベルオプションを追加。シェルエイリアス `alias redmine='papycli --api redmine'` と組み合わせることで、Windows を含む全プラットフォームで `redmine get /projects` のような使い方が可能
- `papycli config completion-script --api <apiname>` オプションを追加。指定した API 名をコマンド名とする補完スクリプトを生成
- symlink を使用していた `papycli config alias` コマンドを完全廃止（Windows Git Bash 非対応だった）
- `config.py` から alias 関連関数を削除し `load_apidef_by_name` ヘルパーを追加

## Breaking Change

`papycli config alias` コマンドは削除されました。以下に移行してください。

```bash
# 旧: papycli config alias redmine
# 新:
alias redmine='papycli --api redmine'
eval "$(papycli config completion-script --api redmine zsh)"  # zsh の場合
```

## Test plan

- [x] `uv run pytest` — 529 passed
- [x] `uv run ruff check` — 新規エラーなし
- [x] `uv run mypy src` — no issues found
- [ ] `papycli --api <apiname> get <resource>` の手動動作確認
- [ ] `papycli config completion-script --api <apiname> zsh` の補完スクリプト生成確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)